### PR TITLE
Fix incorrect "Na slevě se shodneme" when claimedDiscount is null

### DIFF
--- a/lib/templates.mjs
+++ b/lib/templates.mjs
@@ -243,7 +243,9 @@ export function discountTemplate(
   if (discount === null || isNaN(discount)) return null;
 
   discount = Math.trunc(discount * 100) / 100;
-  claimedDiscount = Math.trunc(claimedDiscount * 100) / 100;
+  claimedDiscount = claimedDiscount !== null // important, otherwise Math.trunc(null) would return 0, causing x === claimedDiscount when x is 0 and rendering "Na slevě se shodneme"
+    ? Math.trunc(claimedDiscount * 100) / 100
+    : null;
 
   const titles = new Map([
     [

--- a/lib/templates.mjs
+++ b/lib/templates.mjs
@@ -243,9 +243,10 @@ export function discountTemplate(
   if (discount === null || isNaN(discount)) return null;
 
   discount = Math.trunc(discount * 100) / 100;
-  claimedDiscount = claimedDiscount !== null // important, otherwise Math.trunc(null) would return 0, causing x === claimedDiscount when x is 0 and rendering "Na slevě se shodneme"
-    ? Math.trunc(claimedDiscount * 100) / 100
-    : null;
+  claimedDiscount =
+    claimedDiscount !== null // important, otherwise Math.trunc(null) would return 0, causing x === claimedDiscount when x is 0 and rendering "Na slevě se shodneme"
+      ? Math.trunc(claimedDiscount * 100) / 100
+      : null;
 
   const titles = new Map([
     [


### PR DESCRIPTION
When claimedDiscount is null, it's converted to 0 by Math.trunc, resulting in "Na slevě se shodneme"
![image](https://github.com/topmonks/hlidac-shopu/assets/697301/ee059b4b-9824-497d-ab8d-cc371d74279f)

Current
![image](https://github.com/topmonks/hlidac-shopu/assets/697301/de6f79e0-46ad-4f7f-b933-7db48175a200)

After fix
![image](https://github.com/topmonks/hlidac-shopu/assets/697301/8f455d0f-16cf-4b01-b3a7-127b53dd54b9)

Can be tested at e.g. https://www.eva.cz/zbozi/DRO00845/krtek-na-odpady-900-g/ 
