### PR TITLE
fix(mall): throw on graphql errors

### DIFF
--- a/actors/mall-daily/.actor/actor.json
+++ b/actors/mall-daily/.actor/actor.json
@@ -1,0 +1,6 @@
+{
+	"actorSpecification": 1,
+	"name": "mall-cz-friday",
+	"version": "0.1",
+	"buildTag": "latest"
+}

--- a/actors/mall-daily/.gitignore
+++ b/actors/mall-daily/.gitignore
@@ -1,4 +1,6 @@
 apify_storage
 node_modules
 
-apify_storage
+# Added by Apify CLI
+storage
+.venv

--- a/actors/mall-daily/apify.json
+++ b/actors/mall-daily/apify.json
@@ -1,7 +1,0 @@
-{
-  "name": "mall-cz-friday",
-  "template": "puppeteer_crawler",
-  "version": "0.1",
-  "buildTag": "latest",
-  "env": null
-}

--- a/actors/mall-daily/main.js
+++ b/actors/mall-daily/main.js
@@ -211,7 +211,7 @@ async function main() {
         data: { getCampaign: data } = {},
         errors
       } = json;
-      if (errors) log.error("GraphQL errors", errors);
+      if (errors) throw new Error(errors[0].message);
 
       const {
         productCollection: { items = [] } = {},


### PR DESCRIPTION
Actor will now throw instead of just logging the graphQL error (and thus ending the run early since it considers that there are no more items left).

Closes #2590 