### PR TITLE
fix(ikea): Batch Dataset.push calls to not hit API rate limit

### DIFF
--- a/actors/ikea-daily/search.js
+++ b/actors/ikea-daily/search.js
@@ -141,8 +141,10 @@ function defRouter({ country, stats, rawData }) {
       for (const item of json.results[0].items) {
         stats.inc("items");
         await rawData.pushData(item);
-        await Dataset.pushData(toProduct(item));
       }
+      // We push all data at once to avoid hitting the Apify API rate limit
+      // Note: There is a size limit of 5MB, but these arrays seem to always be <=500 items
+      await Dataset.pushData(json.results[0].items.map(toProduct));
     }
   });
 }


### PR DESCRIPTION
Should resolve #2608 by not calling `Dataset.pushData` individually for each item but the whole results batch. I observed all batches to be <500 items so this shouldn't hit the 5MB size limit either.

Issue is current logs for reference:
```
2025-01-30T01:07:53.747Z INFO  HttpCrawler: Finished! Total 39 requests: 2 succeeded, 37 failed. {"terminal":true}
2025-01-30T01:07:53.753Z INFO  Keboola: Uploading to table ikea_cz
2025-01-30T01:07:53.825Z INFO  Stats: saved
2025-01-30T01:07:53.829Z INFO  Stats: current {"items":6553,"totalCount":0,"failed":37}
2025-01-30T01:07:56.488Z WARN  ApifyClient: API request failed 4 times. Max attempts: 9.
2025-01-30T01:07:56.491Z Cause:ApifyApiError: You have exceeded the rate limit of 200 requests per second
2025-01-30T01:07:56.496Z   clientMethod: DatasetClient.pushItems
2025-01-30T01:07:56.501Z   statusCode: 429
2025-01-30T01:07:56.503Z   type: rate-limit-exceeded
2025-01-30T01:07:56.509Z   attempt: 4
2025-01-30T01:07:56.511Z   httpMethod: post
2025-01-30T01:07:56.513Z   path: /v2/datasets/XrwgwhSVe0aNwBXd2/items
2025-01-30T01:07:56.516Z   stack:
2025-01-30T01:07:56.520Z     at makeRequest (/usr/src/app/node_modules/apify-client/dist/http_client.js:184:30)
2025-01-30T01:07:56.522Z     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-01-30T01:07:56.525Z     at async DatasetClient.pushItems (/usr/src/app/node_modules/apify-client/dist/resource_clients/dataset.js:104:9)
2025-01-30T01:07:56.528Z     at async category (file:///usr/src/app/search.js:156:9)
2025-01-30T01:07:56.530Z     at async wrap (/usr/src/app/node_modules/@apify/timeout/cjs/index.cjs:54:21)
```