### PR TITLE
Datart actor discounts fixes

### DIFF
--- a/actors/datart-daily/main.js
+++ b/actors/datart-daily/main.js
@@ -106,13 +106,13 @@ function extractItems(document, rootUrl, country) {
             .replace(",", ".")
         );
       }
-      let couponDiscount = 0;
-      const couponDiscountFlagEl = productEl.querySelector(".product-flags .flag-color-red");
-      if (couponDiscountFlagEl) {
-        const hasDiscountKeyword = country === Country.CZ && /extra sleva/i.test(couponDiscountFlagEl.textContent);
+      let fixedDiscount = 0;
+      const fixedDiscountFlagEl = productEl.querySelector(".product-flags .flag-color-red");
+      if (fixedDiscountFlagEl) {
+        const hasDiscountKeyword = country === Country.CZ && /extra sleva/i.test(fixedDiscountFlagEl.textContent);
         if (hasDiscountKeyword) {
-          couponDiscount = parseFloat(
-            couponDiscountFlagEl.innerText
+          fixedDiscount = parseFloat(
+            fixedDiscountFlagEl.innerText
               .trim()
               .replace(/[^\d,]+/g, "")
               .replace(",", ".")
@@ -120,11 +120,32 @@ function extractItems(document, rootUrl, country) {
         }
       }
 
+      let percentageDiscount = 0;
+      const percentageDiscountFlagEls = productEl.querySelectorAll(".product-flags .flag");
+      Array.from(percentageDiscountFlagEls).filter((flagEl) => {
+        const hasDiscountKeyword = country === Country.CZ && (
+          /^sleva\s+\d+\s*%$/i.test(flagEl.textContent) // 20 % sleva
+          || /^\d+\s*%\s*sleva$/i.test(flagEl.textContent) // sleva 20 %
+        );
+
+        if (hasDiscountKeyword) {
+          percentageDiscount = parseFloat(
+            flagEl.innerText
+              .trim()
+              .replace(/[^\d,]+/g, "")
+              .replace(",", ".")
+          );
+        }
+      });
+
       result.originalPrice = lowestPriceInLastMonth;
       result.currentPrice = currentPrice;
 
-      if (couponDiscount > 0) {
-        result.currentPrice -= couponDiscount;
+      if (percentageDiscount > 0) {
+        result.currentPrice -= (currentPrice * percentageDiscount) / 100;
+        result.discounted = true;
+      } else if (fixedDiscount > 0) {
+        result.currentPrice -= fixedDiscount;
         result.discounted = true;
       } else {
         result.currentPrice = currentPrice;

--- a/actors/datart-daily/main.js
+++ b/actors/datart-daily/main.js
@@ -122,7 +122,7 @@ function extractItems(document, rootUrl, country) {
 
       let percentageDiscount = 0;
       const percentageDiscountFlagEls = productEl.querySelectorAll(".product-flags .flag");
-      Array.from(percentageDiscountFlagEls).filter((flagEl) => {
+      Array.from(percentageDiscountFlagEls).forEach((flagEl) => {
         const hasDiscountKeyword = country === Country.CZ && (
           /^sleva\s+\d+\s*%$/i.test(flagEl.textContent) // 20 % sleva
           || /^\d+\s*%\s*sleva$/i.test(flagEl.textContent) // sleva 20 %


### PR DESCRIPTION
PR makes sure Datart actor takes discount into consideration.
I found two cases: 
- final price with the % discount is not visible on the category listing
![CleanShot 2025-04-17 at 13 27 50@2x](https://github.com/user-attachments/assets/2cc4ad41-f47e-4654-8020-71489095b6f7)
![CleanShot 2025-04-17 at 13 28 36@2x](https://github.com/user-attachments/assets/8e051eee-e3a2-4477-869c-b8cb2e8327f5)

- effect of the discount code is already visible on the category listing
![CleanShot 2025-04-17 at 13 30 00@2x](https://github.com/user-attachments/assets/fa3bc6fb-414b-4cc2-834c-4dc92dee5850)

