### PR TITLE
fix autoesa missing price

### DIFF
--- a/actors/autoesa/main.js
+++ b/actors/autoesa/main.js
@@ -88,8 +88,8 @@ function toProduct(document, url) {
     }
   }
 
-  const currentPrice = prices.find(price => !price.discount)?.price;
-  const originalPrice = prices.find(price => price.discount)?.price;
+  const currentPrice = prices.find(price => !price.discount)?.price || null;
+  const originalPrice = prices.find(price => price.discount)?.price || null;
 
   return {
     slug: itemId,

--- a/actors/autoesa/main.js
+++ b/actors/autoesa/main.js
@@ -88,8 +88,8 @@ function toProduct(document, url) {
     }
   }
 
-  const currentPrice = prices.find(price => !price.discount)?.price || null;
-  const originalPrice = prices.find(price => price.discount)?.price || null;
+  const currentPrice = prices.find(price => !price.discount)?.price ?? null;
+  const originalPrice = prices.find(price => price.discount)?.price ?? null;
 
   return {
     slug: itemId,


### PR DESCRIPTION
Ahoj, mám prosbu ohledně autoEsa - když chybí originalPrice, actor vrací undefined a mě na tom pak padá uploader do Kebooly. Mohl bys to prosím upravit, aby místo undefined vracel null?
Teda aspoň myslím, že tohle je ten problém, protože keboola uploader mi píše missing column - já ale v datech originalPrice vidím, akorát někde je ten undefined...
```
Problem during upload to Keboola: {"error":"Some columns are missing in the csv file. Missing columns: originalPrice. Expected columns: slug,itemId,itemName,itemUrl,img,currentPrice,originalPrice,currency,discounted,year,km,fuelType,power,shop,shopOrigin,category,date,actRunId.
```