### PR TITLE
fix(actors/datart-daily): Fix Actor for datart.cz (#3195)

### DIFF
--- a/actors/datart-daily/main.js
+++ b/actors/datart-daily/main.js
@@ -82,7 +82,7 @@ function extractItems(document, rootUrl, country) {
 
       const productBoxBuyInfoCart = productEl.querySelector("div.product-box-buy-info > div.product-box-buy-info-cart");
       const itemCartDataTarget = productBoxBuyInfoCart
-        .querySelector("div.item-link-compare > button")
+        .querySelector("div.item-link-compare button")
         .getAttribute("data-target-add");
       if (itemCartDataTarget) {
         const searchParams = new URLSearchParams(itemCartDataTarget);


### PR DESCRIPTION
## Summary
Fixes #3195 - Datart scraper failing with TypeError on getAttribute

## Problem
The scraper was failing with:
```
TypeError: Cannot read properties of null (reading 'getAttribute')
```
at line 86 in actors/datart-daily/main.js

## Root Cause
Datart website added a `<compare-tooltip>` web component wrapper around the compare button, breaking the direct child selector (`>`)

## Solution
Changed line 85 selector from `div.item-link-compare > button` to `div.item-link-compare button` (removed `>`)

## Testing
- Error reproduced: All 67 requests failed before fix
- Fix verified: Successfully scraped 1,072 products  
- Data quality confirmed: itemId, prices, images extracted correctly