### PR TITLE
fix(benu-daily): Fix pagination and originalPrice extraction

### DIFF
--- a/actors/benu-daily/main.js
+++ b/actors/benu-daily/main.js
@@ -38,9 +38,11 @@ function findSUKL(document) {
 
 /**
  * @param {Document} document
- * @returns {Product | null}
+ * @param {string} html
+ * @param {Function} sendRequest
+ * @returns {Promise<Product | null>}
  */
-function extractProduct(document) {
+async function extractProduct(document, html, sendRequest) {
   const script = document.querySelector("#snippet-productRichSnippet-richSnippet").textContent.trim();
   const jsonData = JSON.parse(script);
   const itemId = jsonData.identifier; // can have several identical IDs and differ only in the URL
@@ -48,10 +50,25 @@ function extractProduct(document) {
   if (!itemId || !itemUrl) return null;
   const { offers } = jsonData;
   const currentPrice = offers.price;
-  const originalPriceEl = document.querySelector("#product-detail .buy-box__price-head del");
-  const originalPrice = originalPriceEl
-    ? parseFloat(originalPriceEl.innerText.replace("Kč", "").replace(/\s/g, "").trim())
-    : null;
+
+  // Extract internal product ID from HTML and fetch pricing data from API
+  let originalPrice = null;
+  const apiMatch = html.match(/api\/base\/v1\/products\/(\d+)/);
+  if (apiMatch) {
+    const productId = apiMatch[1];
+    try {
+      const apiUrl = `https://www.benu.cz/api/base/v1/products/${productId}`;
+      const response = await sendRequest({ url: apiUrl });
+      const apiData = JSON.parse(response.body);
+      const rrpPrice = apiData?.data?.attributes?.price?.rrpPrice;
+      if (rrpPrice && rrpPrice !== currentPrice) {
+        originalPrice = rrpPrice;
+      }
+    } catch (e) {
+      log.warning(`Failed to fetch price data from API for product ${productId}:`, e.message);
+    }
+  }
+
   return {
     itemId,
     itemName: jsonData.name,
@@ -59,7 +76,7 @@ function extractProduct(document) {
     img: jsonData.image,
     currentPrice,
     identifierSUKL: findSUKL(document),
-    originalPrice: originalPrice ? originalPrice : null,
+    originalPrice,
     url: jsonData.url,
     category: document.querySelectorAll("ol#breadcrumb > li > a").map(a => a.innerText),
     discounted: originalPrice ? currentPrice < originalPrice : false
@@ -143,7 +160,7 @@ async function main() {
     maxRequestRetries,
     maxRequestsPerMinute: 400,
     proxyConfiguration,
-    async requestHandler({ body, request, crawler }) {
+    async requestHandler({ body, request, crawler, sendRequest }) {
       const { document } = parseHTML(body.toString());
       switch (request.userData.label) {
         case Labels.START:
@@ -179,8 +196,12 @@ async function main() {
         case Labels.PAGE:
           {
             log.info(`START with page ${request.url}`);
-            const maxPage =
-              document.querySelectorAll("p.paging a:not(.next):not(.ico-arr-right)").at(-1)?.innerText?.trim() ?? 0;
+            const paginationLinks = document.querySelectorAll("nav.paging ul.pager li a");
+            // Filter out "Další" (Next) and "Předchozí" (Previous) links, get numeric page numbers
+            const pageNumbers = Array.from(paginationLinks)
+              .map(a => parseInt(a.innerText.trim()))
+              .filter(n => !isNaN(n));
+            const maxPage = pageNumbers.length > 0 ? Math.max(...pageNumbers) : 0;
             const requests = productListingRequests(document);
             await crawler.requestQueue.addRequests(requests);
             if (maxPage !== 0) {
@@ -213,7 +234,7 @@ async function main() {
         case Labels.DETAIL:
           {
             log.info(`START with product ${request.url}`);
-            const result = extractProduct(document);
+            const result = await extractProduct(document, body.toString(), sendRequest);
             if (result) {
               await Dataset.pushData(result);
               stats.inc("items");


### PR DESCRIPTION
## Summary

Fixes #3358 - Benu.cz scraper was returning only ~200 products instead of 23k+ and missing originalPrice for discounted items.

## Changes

### 1. Fixed Pagination (main.js:199-204)
The website was redesigned from `<p class="paging">` to `<nav class="paging">` structure:
- **Before**: `p.paging a:not(.next):not(.ico-arr-right)` returned 0 results
- **After**: `nav.paging ul.pager li a` properly extracts numeric page numbers
- Filters out "Další" (Next) and "Předchozí" (Previous) links

### 2. Fixed originalPrice Extraction (main.js:54-70)
Website uses client-side JavaScript to render discount prices, which HttpCrawler cannot access:
- **Problem**: DOM selectors don't work because prices are JS-rendered
- **Solution**: Extract internal product ID from HTML and call Benu API
- **API**: `GET /api/base/v1/products/{id}` returns complete pricing data
- **Field**: Use `rrpPrice` as originalPrice when different from current price

## Test Results

Pagination working: 328+ products scraped across multiple pages  
originalPrice working: API successfully provides RRP data  
No breaking changes: Same data structure, more reliable source