### PR TITLE
fix(actors/dm-daily): Fix parseItem to parse new data format for items returned by the api

### DIFF
--- a/actors/dm-daily/item.json
+++ b/actors/dm-daily/item.json
@@ -1,0 +1,86 @@
+{
+    "gtin": 5710498270872,
+    "dan": 3061383,
+    "brandName": "DESIGN LETTERS",
+    "title": "Thermoflasche \"Happy\", pink/rosa (500 ml), 1 St",
+    "tileData": {
+        "dan": 3061383,
+        "gtin": 5710498270872,
+        "a11yLabel": "Marke: DESIGN LETTERS; Produktname: Thermoflasche \"Happy\", pink/rosa (500 ml), 1 St; Preis: 22,95 €; Grundpreis: 1 St (22,95 € je 1 St); Ausverkauf Grafik; 4 von 5 Sternen bei 4 Bewertungen",
+        "title": {
+            "tileHeadline": "Thermoflasche \"Happy\", pink/rosa (500 ml), 1 St",
+            "preheadline": "DESIGN LETTERS"
+        },
+        "brand": {
+            "name": "DESIGN LETTERS"
+        },
+        "rating": {
+            "ratingCount": 4,
+            "ratingValue": 4.0
+        },
+        "images": [
+            {
+                "backgroundColor": "#F9F1F3",
+                "alt": "Thermoflasche \"Happy\", pink/rosa (500 ml) DESIGN LETTERS",
+                "tileSrc": "https://products.dm-static.com/images/f_auto,q_auto,c_fit,h_320,w_320/v1755698967/assets/pas/images/513d73de-0fed-4546-9be6-03ed26fe3df6/design-letters-thermoflasche-happy-pink-rosa-500-ml"
+            }
+        ],
+        "eyecatchers": [
+            {
+                "src": "https://media.dm-static.com/images/f_auto,q_auto,c_fit,w_150/v1748357417/products/pim/eyecatcher_sellout_de/sellout_de",
+                "alt": "Ausverkauf Grafik"
+            }
+        ],
+        "self": "/design-letters-thermoflasche-happy-pink-rosa-500-ml-p5710498270872.html",
+        "infoHint": {
+            "text": "Hinweise"
+        },
+        "trackingData": {
+            "currency": "EUR",
+            "categories": [
+                "Deko Limited Editions",
+                "Aufbewahren & To Go"
+            ],
+            "brand": "DESIGN LETTERS",
+            "price": 22.95
+        },
+        "price": {
+            "tileInfos": [
+                "1 St (22,95 € je 1 St)"
+            ],
+            "prefix": "Einzelpreis",
+            "price": {
+                "current": {
+                    "a11yLabel": "Aktueller Preis:",
+                    "value": "22,95 €"
+                },
+                "previous": {
+                    "a11yLabel": "Vorheriger Preis:",
+                    "value": "29,95 €"
+                }
+            }
+        },
+        "netPrice": {
+            "tileInfos": [
+                "1 St (19,29 € je 1 St)"
+            ],
+            "prefix": "Einzelpreis",
+            "price": {
+                "current": {
+                    "a11yLabel": "Aktueller Preis:",
+                    "value": "19,29 €"
+                },
+                "previous": {
+                    "a11yLabel": "Vorheriger Preis:",
+                    "value": "25,17 €"
+                }
+            }
+        }
+    },
+    "context": {
+        "rating": {
+            "ratingValue": 4.0,
+            "ratingCount": 4
+        }
+    }
+}

--- a/actors/dm-daily/main.js
+++ b/actors/dm-daily/main.js
@@ -93,11 +93,16 @@ function parseItem(item, country, category) {
                           .replace(",", ".")) :
                         null
 
+  // inStock information was moved to a different API call:
+  // https://products.dm.de/availability/api/v1/tiles/CZ/<id>
+  // Not necessary to make the extra call. But the Keboola table schema
+  // requires it, so we include it (set to null)
   return {
     itemId: p.gtin,
     itemName: `${p.title.preheadline} ${p.title.tileHeadline}`,
     itemUrl: createProductUrl(country, p.self),
     img: p.images[0]?.tileSrc ?? null,
+    inStock: null,
     currentPrice,
     originalPrice,
     currency: p.trackingData.currency,

--- a/actors/dm-daily/main.js
+++ b/actors/dm-daily/main.js
@@ -3,7 +3,6 @@ import { HttpCrawler } from "@crawlee/http";
 import { ActorType } from "@hlidac-shopu/actors-common/actor-type.js";
 import { getInput } from "@hlidac-shopu/actors-common/crawler.js";
 import { uploadToKeboola } from "@hlidac-shopu/actors-common/keboola.js";
-import { currencyToISO4217 } from "@hlidac-shopu/actors-common/product.js";
 import rollbar from "@hlidac-shopu/actors-common/rollbar.js";
 import { withPersistedStats } from "@hckr_/apify-persistent-stats";
 import { shopName } from "@hlidac-shopu/lib/shops.mjs";
@@ -77,25 +76,33 @@ function* traverseCategories(categories, names = []) {
   }
 }
 
-function parseItem(p, country, category) {
+/*
+  See item.json for a sample response from the API for an item
+*/
+function parseItem(item, country, category) {
+  const p = item.tileData;
+
+  const currentPrice = parseFloat(p.price.price.current.value
+                        .trim()
+                        .replace(/[^\d,]+/g, "")
+                        .replace(",", "."));
+  const originalPrice = p.price.price.previous ?
+                        parseFloat(p.price.price.previous.value
+                          .trim()
+                          .replace(/[^\d,]+/g, "")
+                          .replace(",", ".")) :
+                        null
+
   return {
     itemId: p.gtin,
-    itemName: `${p.brandName} ${p.name}`,
-    itemUrl: createProductUrl(country, p.relativeProductUrl),
-    img: p.imageUrlTemplates?.[0]?.replace("{transformations}", "f_auto,q_auto,c_fit,w_260,h_270") ?? null,
-    inStock: p.purchasable,
-    currentPrice: p.price.value,
-    originalPrice: p.isSellout
-      ? parseFloat(
-          p.selloutPrice.formattedValue
-            .trim()
-            .replace(/[^\d,]+/g, "")
-            .replace(",", ".")
-        )
-      : null,
-    currency: currencyToISO4217(p.price.currencySymbol),
+    itemName: `${p.title.preheadline} ${p.title.tileHeadline}`,
+    itemUrl: createProductUrl(country, p.self),
+    img: p.images[0]?.tileSrc ?? null,
+    currentPrice,
+    originalPrice,
+    currency: p.trackingData.currency,
     category,
-    discounted: p.isSellout
+    discounted: originalPrice ? currentPrice !== originalPrice : false,
   };
 }
 


### PR DESCRIPTION
The `dm-daily` Actor was failing with 

```
2025-10-23T01:34:59.044Z ERROR HttpCrawler: Request failed and reached maximum retries. TypeError: Cannot read properties of undefined (reading 'value')
2025-10-23T01:34:59.046Z     at parseItem (file:///usr/src/app/main.js:87:27)
2025-10-23T01:34:59.047Z     at saveProducts (file:///usr/src/app/main.js:149:22)
2025-10-23T01:34:59.049Z     at handleProducts (file:///usr/src/app/main.js:132:31)
2025-10-23T01:34:59.051Z     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
2025-10-23T01:34:59.052Z     at async HttpCrawler.requestHandler (file:///usr/src/app/main.js:287:18)
```

On inspection, I found that the shape of the response to the `product-search` api has changed. This PR adjusts the `parseItem` function to account for the new shape. 

Note that the new response does not return any information about whether the product is in stock. There is now a new api to get that piece of information:
```https://products.dm.de/availability/api/v1/tiles/CZ/<id>```
Confirmed with @MartinaGelnerova that this field is not required in the output, so I have excluded it rather than make the extra call.

Tested locally after the changes, and it works without errors:

```
INFO  Stats: current {"categories":513,"items":51906,"itemsUnique":0,"itemsDuplicity":23858,"failed":0}
INFO  HttpCrawler: Final request statistics: {"requestsFinished":1239,"requestsFailed":0,"retryHistogram":[1082,145,11,1],"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":6450,"requestsFinishedPerMinute":85,"requestsFailedPerMinute":0,"requestTotalDurationMillis":7991302,"requestsTotal":1239,"crawlerRuntimeMillis":875241}
INFO  HttpCrawler: Finished! Total 1239 requests: 1239 succeeded, 0 failed. {"terminal":true}
INFO  [Status message]: DONE
```

Ready for review: @rarous @MartinaGelnerova 


Closes #3191 