### PR TITLE
fix(actors/lekarna): Import main.js after initializing the Actor

### DIFF
--- a/actors/lekarna-daily/index.js
+++ b/actors/lekarna-daily/index.js
@@ -103,8 +103,9 @@ async function handleProducts({ crawler, document, type }) {
 }
 
 /**
- * @param {string} url
- * @param {ActorType} type
+ * @param {Object} params
+ * @param {string} params.url
+ * @param {ActorType} params.type
  */
 export function getInitialUrls({ url, type }) {
   if (type === ActorType.BlackFriday) {

--- a/actors/lekarna-daily/main.js
+++ b/actors/lekarna-daily/main.js
@@ -1,4 +1,8 @@
 import { Actor } from "apify";
-import { main } from "./index.js";
 
-await Actor.main(main, { statusMessage: "DONE" });
+await Actor.init();
+
+const { main } = await import("./index.js");
+await main();
+
+await Actor.exit("DONE");


### PR DESCRIPTION
Links to https://github.com/topmonks/hlidac-shopu/issues/3192#issuecomment-3461274316.

The issue is caused by accessing KV store before the Actor is initialized which causes the storages to stop working. It's presented in the log like this:
```
2025-10-29T13:51:03.769Z ACTOR: Pulling container image of build CiAGrQjT2whsF6YHC from registry.
2025-10-29T13:51:03.772Z ACTOR: Creating container.
2025-10-29T13:51:03.957Z ACTOR: Starting container.
2025-10-29T13:51:05.119Z INFO  System info {"apifyVersion":"3.5.1","apifyClientVersion":"2.17.0","crawleeVersion":"3.15.1","osType":"Linux","nodeVersion":"v24.9.0"}
2025-10-29T13:51:05.706Z WARN  Actor.getValue() was called but the Actor instance was not initialized.
2025-10-29T13:51:05.715Z Did you forget to call Actor.init()?
```

I'm not sure what is the cause of this but it's likely a side-effect of an import in the `index.js`.

This solution is more of a hack then an actual fix. It allows the storages to work again but the log warning is still there 🤔.

@rarous 

---

Here is a test [run](https://console.apify.com/view/runs/6CZkgyvnr22ZYetFx).