### PR TITLE
fix(actors/lekarna-daily): Fix Actor saving duplicate items

### DIFF
--- a/actors/common/product.js
+++ b/actors/common/product.js
@@ -24,7 +24,7 @@ export async function saveUniqProducts({ products, stats, processedIds }) {
     }
   }
   await Dataset.pushData(newProducts);
-  return products.length;
+  return newProducts.length;
 }
 
 export function currencyToISO4217(currency) {

--- a/actors/lekarna-daily/index.js
+++ b/actors/lekarna-daily/index.js
@@ -133,7 +133,7 @@ export function getInitialUrls({ url, type }) {
 export async function main() {
   rollbar.init();
 
-  const processedIds = useState("processedIds", {});
+  const processedIds = await useState("processedIds", {});
 
   const {
     development = false,


### PR DESCRIPTION
This PR fixes two issues that I found when figuring out why the `lekarna-daily` Actors saves duplicate items into the dataset.

1. When creating the crawler the state that holds all of the processed IDs wasn't created correctly. The `useState` method returns a promise which was never awaited.
2. The `saveUniqProducts` method in the `common` package should return the number of unique items but it returned the length of the input array. This resulted in the logs and stats being wrong.

@rarous @MartinaGelnerova 

---

Test run: https://console.apify.com/view/runs/XNX9YIqfTXFg467pY