### PR TITLE
fix(alza): add missing playwright dependency and update Dockerfile

### DIFF
--- a/actors/alza/Dockerfile
+++ b/actors/alza/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:24
+FROM apify/actor-node-playwright-chrome:24
 
 COPY package.json ./
 

--- a/actors/alza/package.json
+++ b/actors/alza/package.json
@@ -12,7 +12,8 @@
     "@hlidac-shopu/actors-common": "3.2.4",
     "@topmonks/eu-shop-monitoring-lib": "1.2.3",
     "apify": "3.5.1",
-    "jsonc-parser": "^3.2.0"
+    "jsonc-parser": "^3.2.0",
+    "playwright": "1.56.1"
   },
   "devDependencies": {
     "@types/node": "24.9.2",


### PR DESCRIPTION
Fixes the "Cannot find module 'playwright'" error that occurred after switching to PlaywrightCrawler in the Alza actor.

## Changes
- Add playwright 1.56.1 to package.json dependencies
- Update Dockerfile to use apify/actor-node-playwright-chrome:24 base image
- This provides the required Playwright browser binaries

## Testing
Tested with Docker/Podman - actor successfully scraped Black Friday pages with no errors.

Fixes #3396