### PR TITLE
fix(datart-daily): correct discount price extraction for Black Friday sales

### DIFF
--- a/actors/datart-daily/main.js
+++ b/actors/datart-daily/main.js
@@ -97,11 +97,16 @@ function extractItems(document, rootUrl, country) {
       );
 
       let lowestPriceInLastMonth = currentPrice;
-      const lowestPriceInLastMonthEl = productBoxBuyInfoCart.querySelector("div.item-price span.cut-price del");
+      const lowestPriceInLastMonthEl = productBoxBuyInfoCart.querySelector("div.item-price span.cut-price--strike");
       if (lowestPriceInLastMonthEl) {
+        // Remove sr-only content first to avoid extracting digits from screen reader text
+        const srOnly = lowestPriceInLastMonthEl.querySelector('.sr-only');
+        const priceText = srOnly
+          ? lowestPriceInLastMonthEl.innerText.replace(srOnly.innerText, '').trim()
+          : lowestPriceInLastMonthEl.innerText.trim();
+
         lowestPriceInLastMonth = parseFloat(
-          lowestPriceInLastMonthEl.innerText
-            .trim()
+          priceText
             .replace(/[^\d,]+/g, "")
             .replace(",", ".")
         );


### PR DESCRIPTION
Fixes #3195

## Problem
The Datart actor was reporting `currentPrice = originalPrice` for all products during Black Friday sales, making it appear that no discounts were active.

## Root Cause
1. HTML structure changed: The original price selector `span.cut-price del` no longer matches the current DOM structure which uses `span.cut-price span.cut-price--strike`
2. Screen reader text contamination: The price element contains `<span class="sr-only">Nejnižší cena za posledních 30 dní.</span>` which includes the digits "30", causing incorrect price extraction (e.g., "3023990" instead of "23990")

## Solution
- Updated selector from `span.cut-price del` to `span.cut-price--strike`
- Added logic to remove sr-only screen reader text before parsing prices

## Verification
Tested with Black Friday products:
- Before: All products showed originalPrice = currentPrice
- After: Discounts correctly detected (e.g., Samsung Galaxy S25: 19,990 Kč current vs 23,990 Kč original)

## Product Count Investigation
The reported drop from 100k to 80k products is due to Datart removing product sitemaps 3, 4, and 5 (HTTP 410 - Gone). Current sitemap contains 87,675 products across 2 files. This is a legitimate catalog reduction, not a scraper issue.