### PR TITLE
feat(pilulka-daily): Add gift event discount price scraping and improve logging

### DIFF
--- a/actors/pilulka-daily/main.js
+++ b/actors/pilulka-daily/main.js
@@ -122,7 +122,12 @@ function defRouter(processedIds, stats) {
 
       const inStock = product?.offers?.availability === "https://schema.org/InStock";
       const imageUrl = product?.image?.[0];
-      const shortDesc = product?.description;
+      // Getting rid of HTML characters and encoding in text
+      const shortDesc = (() => {
+        const temporaryDescriptionDiv = document.createElement('div');
+        temporaryDescriptionDiv.innerHTML = product?.description;
+        return temporaryDescriptionDiv.innerText;
+      })().trim() || null;
 
       const { id: itemId } = document.querySelector("[componentname='catalog.product']");
       const oldPrice = parseFloatText(

--- a/actors/pilulka-daily/main.js
+++ b/actors/pilulka-daily/main.js
@@ -142,10 +142,6 @@ function defRouter(processedIds, stats) {
         log.warning("Product has discount price only for club members", { url: itemUrl });
       }
 
-      const priceWithCode = parseFloatText(
-        cleanPriceText(document.querySelector(`.price-with-code__price`)?.textContent ?? "")
-      );
-
       if (hasCouponPrice) {
         currentPrice = parseFloatText(
           cleanPriceText(giftPriceElement?.textContent ?? "")
@@ -154,6 +150,10 @@ function defRouter(processedIds, stats) {
         isDiscounted = true;
         log.info("Product has discount", { url: itemUrl });
       } else if (hasDiscount) {
+        const priceWithCode = parseFloatText(
+          cleanPriceText(document.querySelector(`.price-with-code__price`)?.textContent ?? "")
+        );
+
         currentPrice = priceWithCode ?? productPrice;
         originalPrice = oldPrice ?? null;
         isDiscounted = true;

--- a/actors/pilulka-daily/main.js
+++ b/actors/pilulka-daily/main.js
@@ -83,6 +83,20 @@ function initialRequests(country, type, urls) {
   return initialCategoriesUrl(country);
 }
 
+/**
+ * Extracts plain text content from HTML string.
+ * Removes all HTML tags and returns trimmed text content.
+ * HTML entities are automatically decoded by the DOM parser.
+ *
+ * @param {string|null|undefined} textWithHTML - HTML string to extract text from
+ * @returns {string|null} Extracted and trimmed text content, or null if input is falsy or empty
+ */
+function extractTextFromHtml(textWithHTML) {
+  if (!textWithHTML) return null;
+  const { document } = parseHTML(`<div>${textWithHTML}</div>`);
+  return document.querySelector('*')?.textContent?.trim() || null;
+}
+
 function defRouter(processedIds, stats) {
   return createHttpRouter({
     /** @param {HttpCrawlingContext} context */
@@ -122,12 +136,8 @@ function defRouter(processedIds, stats) {
 
       const inStock = product?.offers?.availability === "https://schema.org/InStock";
       const imageUrl = product?.image?.[0];
-      // Getting rid of HTML characters and encoding in text
-      const shortDesc = (() => {
-        const temporaryDescriptionDiv = document.createElement('div');
-        temporaryDescriptionDiv.innerHTML = product?.description;
-        return temporaryDescriptionDiv.innerText;
-      })().trim() || null;
+
+      const shortDesc = extractTextFromHtml(product?.description);
 
       const { id: itemId } = document.querySelector("[componentname='catalog.product']");
       const oldPrice = parseFloatText(
@@ -137,8 +147,7 @@ function defRouter(processedIds, stats) {
       const giftElement = document.querySelector(`.giftEvents__item`);
       const giftPriceElement = document.querySelector(`.giftEvents__price__price`);
 
-      const hasCouponPrice = !!giftPriceElement
-        && !!giftPriceElement
+      const hasCouponPrice = Boolean(giftPriceElement)
         && !/pro\s+členy\s+Pilulka/i.test(giftElement.textContent);
 
       const hasDiscount = !Number.isNaN(oldPrice) && oldPrice > 0;
@@ -189,7 +198,6 @@ function defRouter(processedIds, stats) {
         stats,
         processedIds
       });
-      log.info("Successfully scraped product detail", { url: itemUrl });
     },
     /** @param {HttpCrawlingContext} context */
     async category({ body, enqueueLinks, log, response }) {

--- a/actors/pilulka-daily/main.js
+++ b/actors/pilulka-daily/main.js
@@ -124,12 +124,34 @@ function defRouter(processedIds, stats) {
       const originalPrice = parseFloatText(
         cleanPriceText(document.querySelector(`.product-price-container .product-card-price__old`)?.textContent ?? "")
       );
-      const isDiscounted = !Number.isNaN(originalPrice) && originalPrice > 0;
-      const priceWithCode = parseFloatText(
+
+      const giftElement = document.querySelector(`.giftEvents__item`);
+      const giftPriceElement = document.querySelector(`.giftEvents__price__price`);
+
+      const hasCouponPrice = !!giftPriceElement
+        && !!giftPriceElement
+        && !/pro\s+členy\s+Pilulka/i.test(giftElement.textContent);
+
+      if (!!giftPriceElement && !hasCouponPrice) {
+        log.warning("Product has discount price only for club members", { url: itemUrl });
+      }
+
+      let priceWithCode;
+
+      if (hasCouponPrice) {
+        priceWithCode = parseFloatText(
+          cleanPriceText(giftPriceElement?.textContent ?? "")
+        );
+        log.info("Product has discount", { url: itemUrl });
+      }
+
+      priceWithCode ??= parseFloatText(
         cleanPriceText(document.querySelector(`.price-with-code__price`)?.textContent ?? "")
       );
 
       const breadcrumbs = product?.category?.split(" / ").join(" > "); // "Foo / Bar / Baz" -> "Foo > Bar > Baz"
+
+      const isDiscounted = !Number.isNaN(originalPrice) && originalPrice > 0 || hasCouponPrice;
 
       await saveUniqProducts({
         products: [
@@ -151,6 +173,7 @@ function defRouter(processedIds, stats) {
         stats,
         processedIds
       });
+      log.info("Successfully scraped product detail", { url: itemUrl });
     },
     /** @param {HttpCrawlingContext} context */
     async category({ body, enqueueLinks, log, response }) {

--- a/actors/pilulka-daily/main.js
+++ b/actors/pilulka-daily/main.js
@@ -113,7 +113,6 @@ function defRouter(processedIds, stats) {
       let currentPrice;
       let originalPrice;
       let isDiscounted = false;
-      let isDiscounted = false;
 
       if (productPrice == null || Number.isNaN(productPrice) || productPrice < 0) {
         stats.inc("itemNoPrice");

--- a/actors/pilulka-daily/main.js
+++ b/actors/pilulka-daily/main.js
@@ -108,9 +108,14 @@ function defRouter(processedIds, stats) {
       );
       const product = data.find(x => x["@type"] === "Product");
       const title = product?.name;
-      const currentPrice = product?.offers?.price;
 
-      if (currentPrice == null || Number.isNaN(currentPrice) || currentPrice < 0) {
+      const productPrice  = product?.offers?.price
+      let currentPrice;
+      let originalPrice;
+      let isDiscounted = false;
+      let isDiscounted = false;
+
+      if (productPrice == null || Number.isNaN(productPrice) || productPrice < 0) {
         stats.inc("itemNoPrice");
         log.warning("Item has no price. Skipping...", { url: itemUrl });
         return;
@@ -121,7 +126,7 @@ function defRouter(processedIds, stats) {
       const shortDesc = product?.description;
 
       const { id: itemId } = document.querySelector("[componentname='catalog.product']");
-      const originalPrice = parseFloatText(
+      const oldPrice = parseFloatText(
         cleanPriceText(document.querySelector(`.product-price-container .product-card-price__old`)?.textContent ?? "")
       );
 
@@ -132,26 +137,33 @@ function defRouter(processedIds, stats) {
         && !!giftPriceElement
         && !/pro\s+členy\s+Pilulka/i.test(giftElement.textContent);
 
+      const hasDiscount = !Number.isNaN(oldPrice) && oldPrice > 0;
+
       if (!!giftPriceElement && !hasCouponPrice) {
         log.warning("Product has discount price only for club members", { url: itemUrl });
       }
 
-      let priceWithCode;
-
-      if (hasCouponPrice) {
-        priceWithCode = parseFloatText(
-          cleanPriceText(giftPriceElement?.textContent ?? "")
-        );
-        log.info("Product has discount", { url: itemUrl });
-      }
-
-      priceWithCode ??= parseFloatText(
+      const priceWithCode = parseFloatText(
         cleanPriceText(document.querySelector(`.price-with-code__price`)?.textContent ?? "")
       );
 
-      const breadcrumbs = product?.category?.split(" / ").join(" > "); // "Foo / Bar / Baz" -> "Foo > Bar > Baz"
+      if (hasCouponPrice) {
+        currentPrice = parseFloatText(
+          cleanPriceText(giftPriceElement?.textContent ?? "")
+        );
+        originalPrice = oldPrice ?? productPrice;
+        isDiscounted = true;
+        log.info("Product has discount", { url: itemUrl });
+      } else if (hasDiscount) {
+        currentPrice = priceWithCode ?? productPrice;
+        originalPrice = oldPrice ?? null;
+        isDiscounted = true;
+      } else {
+        currentPrice = productPrice
+        originalPrice = null;
+      }
 
-      const isDiscounted = !Number.isNaN(originalPrice) && originalPrice > 0 || hasCouponPrice;
+      const breadcrumbs = product?.category?.split(" / ").join(" > "); // "Foo / Bar / Baz" -> "Foo > Bar > Baz"
 
       await saveUniqProducts({
         products: [
@@ -165,8 +177,8 @@ function defRouter(processedIds, stats) {
             shortDesc,
             inStock,
             category: breadcrumbs,
-            originalPrice: isDiscounted ? originalPrice : null,
-            currentPrice: priceWithCode ?? currentPrice,
+            originalPrice,
+            currentPrice,
             discounted: isDiscounted
           }
         ],


### PR DESCRIPTION
Related to #3402

Add support for scraping gift event discount prices, excluding club member-only discounts. Include warning for club member prices and info logs for successful scraping.

~~Currently waiting for [test run](https://console.apify.com/actors/rB3OPXsGbl7gHznv8/runs/RWQN44vVhpeEHTaVX) to finish.~~