### PR TITLE
fix(ikea-daily): restore scraping after IKEA API/DOM schema drift

### DIFF
--- a/actors/ikea-daily/search.js
+++ b/actors/ikea-daily/search.js
@@ -84,8 +84,17 @@ function* categoryPagination(country, category, { max, pageSize }) {
   }
 }
 
-function readGlobalNavigation(document) {
-  return JSON.parse(document.querySelector(`.hnf-tabs-navigation > script[type='text/hydration']`).textContent);
+function readTopCategories(document) {
+  const el = document.querySelector("div.hnf-inpage-nav[data-props]");
+  if (!el) {
+    throw new Error("IKEA homepage: div.hnf-inpage-nav[data-props] not found — DOM structure changed");
+  }
+  const props = JSON.parse(el.getAttribute("data-props"));
+  const subs = props?.categories?.subs;
+  if (!Array.isArray(subs) || subs.length === 0) {
+    throw new Error("IKEA homepage: categories.subs missing or empty in hnf-inpage-nav data-props");
+  }
+  return subs;
 }
 
 function toProduct({ product }) {
@@ -99,7 +108,7 @@ function toProduct({ product }) {
     itemId: product.itemNoGlobal,
     itemUrl: product.pipUrl,
     itemName: product.mainImageAlt ?? product.imageAlt,
-    img: product.imageUrl ?? null,
+    img: product.mainImageUrl ?? null,
     currentPrice: isIkeaFamily ? originalPrice : currentPrice,
     originalPrice: isIkeaFamily ? null : originalPrice,
     currency: product.salesPrice.currencyCode,
@@ -123,8 +132,7 @@ function defRouter({ country, stats, rawData }) {
     /** @param {HttpCrawlingContext} ctx */
     async start({ body, crawler }) {
       const { document } = parseHTML(body.toString("utf8"));
-      const nav = readGlobalNavigation(document);
-      const categories = nav.topCategories.map(x => x.id);
+      const categories = readTopCategories(document).map(x => x.id);
       await crawler.addRequests(categories.map(x => getCategoryProducts(country, x)));
     },
     /** @param {HttpCrawlingContext} ctx */
@@ -138,11 +146,16 @@ function defRouter({ country, stats, rawData }) {
         await crawler.addRequests(Array.from(categoryPagination(country, category, { max, pageSize })));
       }
 
+      // The API response mixes PRODUCT items with "breakouts" like PLANNER and
+      // LOGIN_REMINDER (see getCategoryProducts types.breakouts). Only PRODUCT
+      // items have a `product` payload that toProduct can consume.
+      const productItems = json.results[0].items.filter(item => item.product);
+
       // We push all data at once to avoid hitting the Apify API rate limit
       // Note: There is a size limit of 5MB, but these arrays seem to always be <=500 items
-      stats.add("items", json.results[0].items.length);
+      stats.add("items", productItems.length);
       await rawData.pushData(json.results[0].items);
-      await Dataset.pushData(json.results[0].items.map(toProduct));
+      await Dataset.pushData(productItems.map(toProduct));
     }
   });
 }


### PR DESCRIPTION
Fixes #3523. The actor has been returning 0 items because IKEA refactored both the homepage DOM and the `sik.search.blue.cdtapps.com` category API in ways the actor wasn't updated for. Three related schema-drift bugs, single file, +20 / −7.

## Fixes

1. **`readGlobalNavigation` crashed on `null.textContent`** — IKEA removed `.hnf-tabs-navigation` and the `topCategories` key is gone from the hydration JSON. The same 22 top categories are now in `<div class="hnf-inpage-nav" data-props='...'>` as `categories.subs[].id`. Replaced with `readTopCategories(document)` that throws a descriptive error if the structure shifts again.

2. **Product images were silently `null`** — API field renamed from `imageUrl` to `mainImageUrl` (the legacy `index.js` already uses the correct name).

3. **`toProduct` crashed on non-PRODUCT items** — the category API intermixes `PRODUCT` items with `PLANNER` / `LOGIN_REMINDER` "breakouts" (requested via `types.breakouts` in `getCategoryProducts`). Added `.filter(item => item.product)` before mapping — without it, 3 of 22 categories drop all their products.

The new selector was verified on **CZ, SK, DE, PL** (same 22–23 top categories, same `id` scheme across locales).

## Verification

Ran locally end-to-end with `{"country": "cz", "type": "DAILY"}`:

|  | Before | After |
|---|---:|---:|
| Requests succeeded / total | 0 / 1 | **40 / 40** |
| Items scraped | 0 | **14 068** |
| Unique category paths | 0 | **669** |
| Null `itemId` / `currentPrice` / `currency` | — | 0 |