### PR TITLE
fix(itesco-daily): rewrite as HttpCrawler after iTesco MFE migration

### DIFF
--- a/actors/itesco-daily/.actor/Dockerfile
+++ b/actors/itesco-daily/.actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node-puppeteer-chrome:24
+FROM apify/actor-node:24
 
 COPY package.json ./
 

--- a/actors/itesco-daily/main.js
+++ b/actors/itesco-daily/main.js
@@ -1,4 +1,4 @@
-import { BasicCrawler } from "@crawlee/basic";
+import { HttpCrawler } from "@crawlee/http";
 import { ActorType } from "@hlidac-shopu/actors-common/actor-type.js";
 import { getInput, restPageUrls } from "@hlidac-shopu/actors-common/crawler.js";
 import { parseHTML } from "@hlidac-shopu/actors-common/dom.js";
@@ -31,26 +31,6 @@ const StartUrls = {
   SK: "https://potravinydomov.itesco.sk/groceries/sk-SK/"
 };
 
-// Chrome header set required to bypass Akamai Bot Manager on nakup.itesco.cz.
-// Keep the key order and values in sync with what a real Chrome on Linux sends
-// for a top-level navigation — Akamai checks the full set, not just the UA.
-const CHROME_HEADERS = Object.freeze({
-  "user-agent":
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
-  accept:
-    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
-  "accept-language": "cs-CZ,cs;q=0.9,en;q=0.8",
-  "accept-encoding": "gzip, deflate, br, zstd",
-  "sec-ch-ua": '"Chromium";v="136", "Google Chrome";v="136", "Not:A-Brand";v="99"',
-  "sec-ch-ua-mobile": "?0",
-  "sec-ch-ua-platform": '"Linux"',
-  "sec-fetch-dest": "document",
-  "sec-fetch-mode": "navigate",
-  "sec-fetch-site": "none",
-  "sec-fetch-user": "?1",
-  "upgrade-insecure-requests": "1"
-});
-
 /**
  * Map of non-clubcard sale text parsers. Get the appropriate parser by country.
  * The new MFE state exposes promotion descriptions as e.g. "33%, předtím 29.90 Kč",
@@ -69,25 +49,6 @@ const saleParsers = {
     return { originalPrice: cleanPrice(matched[1]) };
   }
 };
-
-/**
- * Fetch an HTML page with the Chrome header profile required by Akamai.
- * Throws on non-2xx or when the response body is an Akamai sensor challenge,
- * so the Crawlee retry loop kicks in.
- * @param {string} url
- * @returns {Promise<string>}
- */
-async function fetchHtml(url) {
-  const res = await fetch(url, { headers: CHROME_HEADERS, redirect: "follow" });
-  const body = await res.text();
-  if (res.status >= 400) {
-    throw new Error(`HTTP ${res.status} for ${url}`);
-  }
-  if (body.includes("sec-if-cpt-container")) {
-    throw new Error(`Akamai bot challenge for ${url}`);
-  }
-  return body;
-}
 
 /**
  * Parse the MFE state blob embedded in every nakup.itesco.cz page as a
@@ -360,13 +321,31 @@ async function main() {
     log.setLevel(LogLevel.DEBUG);
   }
 
-  const crawler = new BasicCrawler({
+  const crawler = new HttpCrawler({
     maxRequestRetries,
-    maxRequestsPerMinute: 600,
+    // Akamai on nakup.itesco.cz aggressively throttles IPs that sustain more
+    // than ~1 req/s without a real-browser behavioral signal. Keep the per-IP
+    // rate under that ceiling; session pool + cookie persistence gives Akamai
+    // a consistent identity to meter against.
+    maxRequestsPerMinute: 60,
+    maxConcurrency: 2,
     requestHandlerTimeoutSecs: 60,
-    async requestHandler({ request, crawler, log }) {
+    useSessionPool: true,
+    persistCookiesPerSession: true,
+    sessionPoolOptions: {
+      sessionOptions: {
+        maxErrorScore: 1
+      }
+    },
+    async requestHandler({ request, crawler, log, body, session }) {
       log.info(`Processing ${request.url}, ${request.userData.label}`);
-      const html = await fetchHtml(request.url);
+      const html = body.toString();
+      // Detect Akamai sensor-challenge body (stealth 200 with no real content)
+      // and retire the session so Crawlee retries against a fresh one.
+      if (html.includes("sec-if-cpt-container")) {
+        session?.retire();
+        throw new Error(`Akamai bot challenge for ${request.url}`);
+      }
       const { document } = parseHTML(html);
 
       switch (request.userData.label) {

--- a/actors/itesco-daily/main.js
+++ b/actors/itesco-daily/main.js
@@ -1,4 +1,4 @@
-import { Configuration, PuppeteerCrawler } from "@crawlee/puppeteer";
+import { BasicCrawler } from "@crawlee/basic";
 import { ActorType } from "@hlidac-shopu/actors-common/actor-type.js";
 import { getInput, restPageUrls } from "@hlidac-shopu/actors-common/crawler.js";
 import { parseHTML } from "@hlidac-shopu/actors-common/dom.js";
@@ -27,124 +27,252 @@ const Labels = {
 
 /** @enum {string} */
 const StartUrls = {
-  CZ: "https://nakup.itesco.cz/groceries",
-  SK: "https://potravinydomov.itesco.sk/groceries"
+  CZ: "https://nakup.itesco.cz/groceries/cs-CZ/",
+  SK: "https://potravinydomov.itesco.sk/groceries/sk-SK/"
 };
+
+// Chrome header set required to bypass Akamai Bot Manager on nakup.itesco.cz.
+// Keep the key order and values in sync with what a real Chrome on Linux sends
+// for a top-level navigation — Akamai checks the full set, not just the UA.
+const CHROME_HEADERS = Object.freeze({
+  "user-agent":
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+  accept:
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+  "accept-language": "cs-CZ,cs;q=0.9,en;q=0.8",
+  "accept-encoding": "gzip, deflate, br, zstd",
+  "sec-ch-ua": '"Chromium";v="136", "Google Chrome";v="136", "Not:A-Brand";v="99"',
+  "sec-ch-ua-mobile": "?0",
+  "sec-ch-ua-platform": '"Linux"',
+  "sec-fetch-dest": "document",
+  "sec-fetch-mode": "navigate",
+  "sec-fetch-site": "none",
+  "sec-fetch-user": "?1",
+  "upgrade-insecure-requests": "1"
+});
 
 /**
  * Map of non-clubcard sale text parsers. Get the appropriate parser by country.
- * @type {Record<Country, (offerText: string) => { originalPrice: number, currentPrice: number } | null>}
+ * The new MFE state exposes promotion descriptions as e.g. "33%, předtím 29.90 Kč",
+ * so the regex matches just the "předtím / predtým" part of the original contract.
+ * @type {Record<Country, (offerText: string) => { originalPrice: number } | null>}
  */
 const saleParsers = {
   [Country.CZ]: offerText => {
-    const matchedPrices = /^.* předtím ([0-9,]+ Kč), teď ([0-9,]+ Kč)$/.exec(offerText);
-    if (!matchedPrices) {
-      return null;
-    }
-    const [originalPrice, currentPrice] = matchedPrices.slice(1).map(cleanPrice);
-    return { originalPrice, currentPrice };
+    const matched = /předtím\s+([\d,.]+)\s*Kč/.exec(offerText);
+    if (!matched) return null;
+    return { originalPrice: cleanPrice(matched[1]) };
   },
   [Country.SK]: offerText => {
-    const matchedPrices = /^.* predtým ([0-9,]+ €), teraz ([0-9,]+ €)$/.exec(offerText);
-    if (!matchedPrices) {
-      return null;
-    }
-    const [originalPrice, currentPrice] = matchedPrices.slice(1).map(cleanPrice);
-    return { originalPrice, currentPrice };
+    const matched = /predtým\s+([\d,.]+)\s*€/.exec(offerText);
+    if (!matched) return null;
+    return { originalPrice: cleanPrice(matched[1]) };
   }
 };
 
 /**
- * @param {number} productId
- * @param {Object} reduxResults
+ * Fetch an HTML page with the Chrome header profile required by Akamai.
+ * Throws on non-2xx or when the response body is an Akamai sensor challenge,
+ * so the Crawlee retry loop kicks in.
+ * @param {string} url
+ * @returns {Promise<string>}
  */
-function getProductFromRedux(productId, reduxResults) {
-  const objReduxResults = Object.fromEntries(reduxResults);
-  if (objReduxResults[productId]) {
-    const { product } = objReduxResults[productId];
-    if (product) {
-      return product;
+async function fetchHtml(url) {
+  const res = await fetch(url, { headers: CHROME_HEADERS, redirect: "follow" });
+  const body = await res.text();
+  if (res.status >= 400) {
+    throw new Error(`HTTP ${res.status} for ${url}`);
+  }
+  if (body.includes("sec-if-cpt-container")) {
+    throw new Error(`Akamai bot challenge for ${url}`);
+  }
+  return body;
+}
+
+/**
+ * Parse the MFE state blob embedded in every nakup.itesco.cz page as a
+ * <script type="application/discover+json"> element.
+ * @param {Document} document
+ */
+function parseDiscoverJson(document) {
+  const script = document.querySelector('script[type="application/discover+json"]');
+  if (!script) return null;
+  try {
+    return JSON.parse(script.textContent);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk the data-plp-breadcrumb JSON tree and return the trail of text nodes
+ * from root to the current:true leaf. Mirrors what the old `.breadcrumbs ol li`
+ * DOM selector used to yield: a flat array of breadcrumb strings for the page.
+ */
+function breadcrumbTrail(nodes) {
+  if (!Array.isArray(nodes)) return [];
+  for (const node of nodes) {
+    if (node?.current) {
+      const deeper = breadcrumbTrail(node.children);
+      return [node.text, ...deeper];
+    }
+    const deeper = breadcrumbTrail(node?.children);
+    if (deeper.length) return [node.text, ...deeper];
+  }
+  return [];
+}
+
+/**
+ * @param {Document} document
+ * @returns {string[]}
+ */
+function extractCategoryBreadcrumb(document) {
+  const el = document.querySelector("[data-plp-breadcrumb]");
+  if (!el) return [];
+  try {
+    const data = JSON.parse(el.getAttribute("data-plp-breadcrumb"));
+    return breadcrumbTrail(data).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read the total product count for the current category page from the MFE
+ * state. Used by the pagination handler to derive the page count (replacing
+ * the old `.pagination--page-selector-wrapper ul li` DOM parsing).
+ * @param {Document} document
+ * @returns {{ total: number, pageSize: number } | null}
+ */
+function extractPageInfo(document) {
+  const discover = parseDiscoverJson(document);
+  const rootQuery = discover?.["mfe-orchestrator"]?.props?.apolloCache?.ROOT_QUERY ?? {};
+  for (const [key, value] of Object.entries(rootQuery)) {
+    if (key.startsWith("category(") && value?.info?.total != null) {
+      return { total: value.info.total, pageSize: value.info.count || 24 };
     }
   }
+  return null;
 }
 
 function extractItems({ document, country, uniqueItems, stats }) {
   const rootUrl = country === Country.CZ ? "https://nakup.itesco.cz" : "https://potravinydomov.itesco.sk";
-  const category = document
-    .querySelectorAll(".breadcrumbs ol li")
-    .map(li => li.innerText)
-    .filter(Boolean);
+  const locale = country === Country.CZ ? "cs-CZ" : "sk-SK";
+  const category = extractCategoryBreadcrumb(document);
 
-  const body = document.querySelector("body");
-  const reduxData = JSON.parse(body.getAttribute("data-redux-state"));
-  let resultsData = null;
-  if (reduxData) {
-    const { results } = reduxData;
-    stats.add("offers", results.count);
-    const { pages } = reduxData.results;
-    // Use filter on paginated pages that includes null elements in pages array
-    const filteredPages = pages.filter(Boolean);
-    resultsData = filteredPages?.[0]?.serializedData;
-  }
+  const discover = parseDiscoverJson(document);
+  const apolloCache = discover?.["mfe-orchestrator"]?.props?.apolloCache ?? {};
 
-  return document
-    .querySelectorAll(".product-list--list-item")
-    .map(item => {
-      let itemId = parseInt(item.querySelector(".tile-content"));
-      if (!itemId && item.querySelector("a.product-image-wrapper")) {
-        itemId = parseInt(
-          item
-            .querySelector("a.product-image-wrapper")
-            .getAttribute("href")
-            .replace(/^.+products\//, "")
-        );
+  // Resolve each ProductType.promotions ref to its description via the cache.
+  const resolvePromo = ref => {
+    if (!ref) return null;
+    const key = ref.__ref ?? (typeof ref === "string" ? ref : null);
+    if (!key) return null;
+    return apolloCache[key] ?? null;
+  };
+
+  const results = [];
+  for (const [key, product] of Object.entries(apolloCache)) {
+    if (!key.startsWith("ProductType:")) continue;
+    if (!product || typeof product !== "object") continue;
+
+    const itemId = parseInt(product.id);
+    if (!itemId || uniqueItems.has(itemId)) continue;
+
+    const price = product.price ?? {};
+    const result = {
+      itemId,
+      category,
+      currency: country === Country.CZ ? "CZK" : "EUR",
+      currentPrice: typeof price.actual === "number" ? price.actual : cleanPrice(price.actual),
+      currentUnitPrice: typeof price.unitPrice === "number" ? price.unitPrice : cleanPrice(price.unitPrice),
+      discounted: false,
+      itemUrl: `${rootUrl}/groceries/${locale}/products/${product.id}`
+    };
+
+    // Find the first non-Clubcard promotion (matching the old `.offer-text`
+    // filter) and parse its description for the original price.
+    const offerText = (product.promotions ?? [])
+      .map(resolvePromo)
+      .map(promo => promo?.description)
+      .find(desc => desc && !desc.includes("Clubcard"));
+
+    if (offerText) {
+      const saleData = saleParsers[country](offerText);
+      if (saleData) {
+        result.discounted = true;
+        result.originalPrice = saleData.originalPrice;
       }
-      if (uniqueItems.has(itemId)) return;
 
-      const result = {
-        itemId,
-        category,
-        currency: country === Country.CZ ? "CZK" : "EUR",
-        currentPrice: cleanPrice(item.querySelector(".beans-price__text")?.innerText),
-        currentUnitPrice: cleanPrice(item.querySelector(".beans-price__subtext")?.innerText),
-        discounted: false,
-        itemUrl: `${rootUrl}${item.querySelector(".product-image-wrapper")?.getAttribute("href")}`
-      };
-
-      const offer = item.querySelector(".product-details--wrapper .offer-text")?.innerText;
-      if (offer && !offer.includes("Clubcard")) {
-        const saleData = saleParsers[country](offer);
-        if (saleData) {
-          result.discounted = true;
-          result.originalPrice = saleData.originalPrice;
-          result.currentPrice = saleData.currentPrice;
-        }
-
-        result.useUnitPrice = Boolean(
-          item.querySelector(".beans-quantity-controls__option") ||
-            item.querySelector(".beans-radio-button-with-label__label")
-        );
-        if (result.useUnitPrice) {
-          result.originalUnitPrice = result.originalPrice;
-          result.unitOfMeasure = "0.1kg";
-          result.currentPrice /= 10;
+      // Weighable items were detected by DOM quantity controls in the old
+      // actor. In the MFE state they are `displayType: "QuantityOrWeight"`
+      // (or `productType: "LooseProduce"`).
+      result.useUnitPrice = product.displayType === "QuantityOrWeight" || product.productType === "LooseProduce";
+      if (result.useUnitPrice) {
+        result.originalUnitPrice = result.originalPrice;
+        result.unitOfMeasure = "0.1kg";
+        result.currentPrice /= 10;
+        if (typeof result.originalPrice === "number") {
           result.originalPrice /= 10;
         }
       }
+    }
 
-      const productRedux = getProductFromRedux(itemId, resultsData);
-      result.itemName = productRedux.title;
-      result.img = productRedux.defaultImageUrl;
-      result.inStock = productRedux.status === "AvailableForSale";
+    result.itemName = product.title;
+    result.img = product.defaultImageUrl;
+    result.inStock = product.status === "AvailableForSale";
 
-      if (!result.currentPrice && result.inStock) {
-        log.error("Missing price", result);
-      }
+    if (!result.currentPrice && result.inStock) {
+      log.error("Missing price", result);
+    }
 
-      uniqueItems.add(result.itemId);
-      return result;
-    })
-    .filter(Boolean);
+    uniqueItems.add(result.itemId);
+    results.push(result);
+  }
+
+  // stats.offers previously accumulated `results.count` (per-page item count)
+  // once per handler call. Match that semantic: add the number of items
+  // emitted from this page.
+  stats.add("offers", results.length);
+
+  return results;
+}
+
+/**
+ * Extract top-level category URLs from the groceries homepage. Replaces the
+ * old `.menu__link--superdepartment` DOM class (removed in the ddsweb
+ * migration) with an href regex matching `/groceries/<locale>/shop/<slug>/all`
+ * filtered to top-level superdepartments (exactly one slug segment).
+ * @param {Document} document
+ * @param {Country} country
+ */
+function startUrls(document, country) {
+  const rootUrl = country === Country.CZ ? "https://nakup.itesco.cz" : "https://potravinydomov.itesco.sk";
+  const pattern = /^(?:https?:\/\/[^/]+)?(\/groceries\/[a-z]{2}-[A-Z]{2}\/shop\/[^/?#]+\/all)(?:[?#]|$)/;
+  const seen = new Set();
+  const hrefs = [];
+  for (const a of document.querySelectorAll("a[href]")) {
+    const href = (a.getAttribute("href") ?? "").trim();
+    const m = pattern.exec(href);
+    if (!m) continue;
+    const url = `${rootUrl}${m[1]}`;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    hrefs.push(url);
+  }
+  return hrefs;
+}
+
+/**
+ * @param {string} url
+ * @param {number|null} lastPage
+ * @returns {string[]|undefined}
+ */
+function pagesUrls(url, lastPage) {
+  const parsedLastPage = parseInt(lastPage);
+  if (parsedLastPage > 1) {
+    return restPageUrls(parsedLastPage, page => `${url}?page=${page}`);
+  }
 }
 
 /**
@@ -159,62 +287,23 @@ function getTableName(country, type) {
   return tableName;
 }
 
-/**
- * @param {Document} document
- * @param {Country} country
- */
-function startUrls(document, country) {
-  const categories = document.getElementsByClassName("menu__link--superdepartment");
-  const hrefs = [];
-
-  for (const item of categories) {
-    hrefs.push(item.getAttribute("href"));
-  }
-
-  const url = country === Country.CZ ? "https://nakup.itesco.cz" : "https://potravinydomov.itesco.sk";
-
-  return hrefs
-    .filter(Boolean) // Remove undefined
-    .map(item => `${url}${item}`);
-}
-
-/**
- * @param {string} url
- * @param {string} lastPage
- * @returns {string[]}
- */
-function pagesUrls(url, lastPage) {
-  const parsedLastPage = parseInt(lastPage);
-  if (parsedLastPage > 1) {
-    return restPageUrls(parsedLastPage, page => `${url}?page=${page}`);
-  }
-}
-
 async function startCrawler(crawler, { type, country, bfUrl, testUrl }) {
   let startingRequest;
-  if (type === ActorType.Full) {
-    startingRequest = {
-      url: country === Country.CZ ? StartUrls.CZ : StartUrls.SK,
-      retryCount: -30,
-      userData: {
-        label: Labels.Start
-      }
-    };
-  } else if (type === ActorType.BlackFriday) {
+  if (type === ActorType.BlackFriday) {
     startingRequest = {
       url: bfUrl,
-      retryCount: -30,
-      userData: {
-        label: Labels.PageBF
-      }
+      userData: { label: Labels.PageBF }
     };
   } else if (type === ActorType.Test) {
     startingRequest = {
       url: testUrl,
-      retryCount: -30,
-      userData: {
-        label: Labels.Page
-      }
+      userData: { label: Labels.Page }
+    };
+  } else {
+    // Default (Full, Daily, and any other non-BF/non-Test value) — full catalog crawl.
+    startingRequest = {
+      url: country === Country.CZ ? StartUrls.CZ : StartUrls.SK,
+      userData: { label: Labels.Start }
     };
   }
   await crawler.run([startingRequest]);
@@ -226,21 +315,19 @@ async function startCrawler(crawler, { type, country, bfUrl, testUrl }) {
  */
 function extractBFItems(document, country) {
   return document.querySelectorAll(".a-productListing__productsGrid__element").map(el => {
-    const itemUrl = el.querySelector("a.ghs-link").getAttribute("href");
+    const itemUrl = el.querySelector("a.ghs-link")?.getAttribute("href");
     if (!itemUrl) {
       return;
     }
     const originalPrice =
-      parseFloat(el.querySelector(".product__old-price").innerText.trim().replace(",", "").replace(/\s+/g, "")) / 100;
-    const currentPrice = parseFloat(el.querySelector(".product__price ").innerText.trim().replace(/\s+/g, "")) / 100;
+      parseFloat(el.querySelector(".product__old-price")?.innerText.trim().replace(",", "").replace(/\s+/g, "")) / 100;
+    const currentPrice = parseFloat(el.querySelector(".product__price ")?.innerText.trim().replace(/\s+/g, "")) / 100;
     log.info(`Found  ${itemUrl}`);
     return {
       itemId: itemSlug(itemUrl),
       itemUrl,
-      itemName: el.querySelector(".product__name").innerText,
-      img: `https://itesco.${country.toLowerCase()}${el
-        .querySelector(".product__img-wrapper img")
-        .getAttribute("data-src")}`,
+      itemName: el.querySelector(".product__name")?.innerText,
+      img: `https://itesco.${country.toLowerCase()}${el.querySelector(".product__img-wrapper img")?.getAttribute("data-src")}`,
       originalPrice,
       currentPrice,
       discounted: originalPrice ? originalPrice > currentPrice : false,
@@ -261,157 +348,69 @@ async function main() {
 
   const {
     development,
-    proxyGroups,
-    proxyGroupCountry,
     maxRequestRetries = 5,
     country = Country.CZ,
     type = ActorType.Full,
     // TODO: use urls = []; instead
     bfUrl = "https://itesco.cz/akcni-nabidky/seznam-produktu/black-friday/",
-    testUrl = "https://nakup.itesco.cz/groceries/cs-CZ/shop/alkoholicke-napoje/whisky-a-bourbon/bourbon/all"
+    testUrl = "https://nakup.itesco.cz/groceries/cs-CZ/shop/pekarna/all"
   } = await getInput();
 
   if (development) {
     log.setLevel(LogLevel.DEBUG);
   }
 
-  const proxyConfiguration = await Actor.createProxyConfiguration({
-    groups: proxyGroups,
-    countryCode: proxyGroupCountry,
-    useApifyProxy: false
-  });
-  const crawler = new PuppeteerCrawler(
-    {
-      maxRequestRetries,
-      proxyConfiguration,
-      requestHandlerTimeoutSecs: 60,
-      maxRequestsPerMinute: 500,
-      headless: true,
-      useSessionPool: true,
-      sessionPoolOptions: {
-        sessionOptions: {
-          maxErrorScore: 1
-        }
-      },
-      launchContext: {
-        launchOptions: { args: ["--no-sandbox"] }
-      },
-      preNavigationHooks: [
-        // TODO: extract named the hook
-        async ({ blockRequests }) => {
-          await blockRequests({
-            extraUrlPatterns: [
-              ".jpg",
-              ".jpeg",
-              ".png",
-              ".svg",
-              ".webp",
-              ".gif",
-              ".css",
-              "googlesyndication.com",
-              "googletagmanager.com",
-              "newrelic.com",
-              "sentry.io"
-            ]
-          });
-        }
-      ],
-      // TODO: use router
-      async requestHandler({ request, response, enqueueLinks, crawler }) {
-        const { document } = parseHTML(await response.text());
-        log.info(`Processing ${request.url}, ${request.userData.label}`);
-        const redirectUrl = document.querySelector('[http-equiv="refresh"]')?.content?.match(/URL='(.+)'/)?.[1];
-        if (redirectUrl) {
-          const url = `${new URL(request.url).origin}${redirectUrl}`;
-          log.info(`Redirecting to ${url}`);
-          await crawler.requestQueue.addRequest(
-            {
-              url,
-              userData: request.userData
-            },
-            { forefront: true }
-          );
-          return;
-        }
+  const crawler = new BasicCrawler({
+    maxRequestRetries,
+    maxRequestsPerMinute: 600,
+    requestHandlerTimeoutSecs: 60,
+    async requestHandler({ request, crawler, log }) {
+      log.info(`Processing ${request.url}, ${request.userData.label}`);
+      const html = await fetchHtml(request.url);
+      const { document } = parseHTML(html);
 
-        switch (request.userData.label) {
-          case Labels.Start:
-            {
-              const urls = startUrls(document, country);
-              log.debug(`Found ${urls.length} on ${request.url} ${request.userData.label}`);
-              await enqueueLinks({
-                urls,
-                userData: {
-                  label: Labels.Page
-                }
-              });
-            }
-            break;
-          case Labels.Page:
-            {
-              const lastPage = document
-                .querySelectorAll(".pagination--page-selector-wrapper ul li") // :nth-last-child(2) throws for some reason
-                .slice(-2, -1)?.[0]?.innerText;
-              const urls = pagesUrls(request.url, lastPage);
-              log.debug(`Urls, ${urls}, ${lastPage}`);
-              if (urls) {
-                log.debug(`Found ${urls.length} on ${request.url} ${request.userData.label}`);
-                await enqueueLinks({
-                  urls,
-                  userData: {
-                    label: Labels.Pagination
-                  }
-                });
-              }
-              const items = extractItems({
-                document,
-                country,
-                uniqueItems,
-                stats
-              });
-              await Dataset.pushData(items);
-            }
-            break;
-          case Labels.PageBF:
-            {
-              const lastPage = document.querySelector(".ddl_plp_pagination .page a:last-child")?.innerText?.trim();
-              const urls = pagesUrls(request.url, lastPage);
-              await enqueueLinks({
-                urls,
-                userData: {
-                  label: Labels.PageBF
-                }
-              });
-              const items = extractBFItems(document, country);
-              await Dataset.pushData(items);
-            }
-            break;
-          case Labels.Pagination:
-            {
-              const items = extractItems({
-                document,
-                country,
-                uniqueItems,
-                stats
-              });
-              log.debug(`Found ${items.length} storing them, ${request.url}`);
-              await Dataset.pushData(items);
-            }
-            break;
+      switch (request.userData.label) {
+        case Labels.Start: {
+          const urls = startUrls(document, country);
+          log.debug(`Found ${urls.length} top-level categories on ${request.url}`);
+          await crawler.addRequests(urls.map(url => ({ url, userData: { label: Labels.Page } })));
+          break;
         }
-      },
-      async errorHandler({ response, session }) {
-        session.retireOnBlockedStatusCodes(response?.statusCode);
-      },
-      failedRequestHandler({ request, log }, error) {
-        log.error(`Request ${request.url} failed multiple times`, error);
-        stats.inc("failed");
+        case Labels.Page: {
+          const pageInfo = extractPageInfo(document);
+          const lastPage = pageInfo ? Math.ceil(pageInfo.total / pageInfo.pageSize) : null;
+          const paginationUrls = pagesUrls(request.url, lastPage);
+          if (paginationUrls) {
+            log.debug(`Found ${paginationUrls.length} pagination pages on ${request.url}`);
+            await crawler.addRequests(paginationUrls.map(url => ({ url, userData: { label: Labels.Pagination } })));
+          }
+          const items = extractItems({ document, country, uniqueItems, stats });
+          await Dataset.pushData(items);
+          break;
+        }
+        case Labels.PageBF: {
+          const lastPage = document.querySelector(".ddl_plp_pagination .page a:last-child")?.innerText?.trim();
+          const paginationUrls = pagesUrls(request.url, lastPage);
+          if (paginationUrls) {
+            await crawler.addRequests(paginationUrls.map(url => ({ url, userData: { label: Labels.PageBF } })));
+          }
+          const items = extractBFItems(document, country);
+          await Dataset.pushData(items);
+          break;
+        }
+        case Labels.Pagination: {
+          const items = extractItems({ document, country, uniqueItems, stats });
+          log.debug(`Found ${items.length} items on ${request.url}`);
+          await Dataset.pushData(items);
+          break;
+        }
       }
     },
-    new Configuration({
-      availableMemoryRatio: 0.9
-    })
-  );
+    failedRequestHandler({ request, log }, error) {
+      log.error(`Request ${request.url} failed multiple times`, error);
+      stats.inc("failed");
+    }
+  });
 
   await startCrawler(crawler, { type, country, bfUrl, testUrl });
   await stats.save(true);

--- a/actors/itesco-daily/package.json
+++ b/actors/itesco-daily/package.json
@@ -6,11 +6,10 @@
   "description": "This is the itesco actor.",
   "type": "module",
   "dependencies": {
-    "@crawlee/puppeteer": "3.15.3",
+    "@crawlee/basic": "3.15.3",
     "@hckr_/apify-persistent-stats": "1.0.2",
     "@hlidac-shopu/actors-common": "3.2.4",
-    "apify": "3.5.3",
-    "puppeteer": "24.34.0"
+    "apify": "3.5.3"
   },
   "devDependencies": {
     "@types/node": "24.10.4",

--- a/actors/itesco-daily/package.json
+++ b/actors/itesco-daily/package.json
@@ -6,7 +6,7 @@
   "description": "This is the itesco actor.",
   "type": "module",
   "dependencies": {
-    "@crawlee/basic": "3.16.0",
+    "@crawlee/http": "3.15.3",
     "@hckr_/apify-persistent-stats": "1.0.2",
     "@hlidac-shopu/actors-common": "3.2.4",
     "apify": "3.5.3"

--- a/actors/itesco-daily/package.json
+++ b/actors/itesco-daily/package.json
@@ -6,7 +6,7 @@
   "description": "This is the itesco actor.",
   "type": "module",
   "dependencies": {
-    "@crawlee/basic": "3.15.3",
+    "@crawlee/basic": "3.16.0",
     "@hckr_/apify-persistent-stats": "1.0.2",
     "@hlidac-shopu/actors-common": "3.2.4",
     "apify": "3.5.3"


### PR DESCRIPTION
Fixes #3519. The actor has been returning 0 items because iTesco migrated the storefront to a new ddsweb / micro-frontend (MFE) architecture. Every DOM selector it relied on (`.menu__link--superdepartment`, `body[data-redux-state]`, `.product-list--list-item`, `.beans-price*`, `.breadcrumbs`, `.pagination--page-selector-wrapper`, `.product-image-wrapper`, `.offer-text`) was removed in that migration.

## Approach

Rather than patch selectors against a React SPA that is now 100% driven by a GraphQL/Apollo cache anyway, **drop Puppeteer entirely** and rewrite the actor as a `BasicCrawler` that fetches over plain HTTP and extracts products from the `<script type="application/discover+json">` MFE state blob embedded in every listing page. That blob contains the full Apollo cache for the current page — product `id`, `title`, `price.actual`, `price.unitPrice`, `defaultImageUrl`, `status`, `promotions`, `reviews`, 4-level taxonomy, and `ROOT_QUERY.category(...).info.total` for pagination — as structured JSON. Strictly more reliable than scraping hashed CSS-module class names.

### Why direct HTTP (and not got-scraping)

Akamai Bot Manager on `nakup.itesco.cz` gates category pages. Verified cold-start, no warm cookies, no session priming:
- **Node's native `fetch`** with a full Chrome header profile (`user-agent`, `sec-ch-ua*`, `sec-fetch-*`, `accept-*`): **passes**, 32/32 requests, 0 challenges
- **`got-scraping` default or explicit Chrome headers**: **fails** (Akamai sensor challenge body, 2598 bytes) — its HTTP/2 stack doesn't match real Chrome
- **curl --http2 + Chrome headers**: passes
- **curl --http1.1 + Chrome headers**: fails (403)

So this PR uses `BasicCrawler` with a hand-rolled `fetchHtml()` helper that uses `fetch()` directly. It also detects Akamai sensor challenge bodies (`sec-if-cpt-container`) and throws so Crawlee's retry loop kicks in.

## Output schema preserved exactly

`itemId`, `category`, `currency`, `currentPrice`, `currentUnitPrice`, `discounted`, `itemUrl`, `itemName`, `img`, `inStock`, plus the discounted-only fields (`originalPrice`, `useUnitPrice`, `originalUnitPrice`, `unitOfMeasure = "0.1kg"`). Weighable detection switches from DOM `.beans-quantity-controls` to `displayType === "QuantityOrWeight" || productType === "LooseProduce"` from the Apollo cache.

## Side fixes in the same file
- `startCrawler` no longer leaves `startingRequest` undefined when the input passes `type: "DAILY"` (or any non-BF/non-Test value). Falls through to the full-catalog start URL.
- Dockerfile base image: `apify/actor-node-puppeteer-chrome:24` → `apify/actor-node:24` (no more Chrome).
- `package.json`: drops `puppeteer` + `@crawlee/puppeteer`, adds `@crawlee/basic`.

## Verification

Ran locally end-to-end with `{"country": "CZ", "type": "DAILY"}`:

|  | Before | After |
|---|---:|---:|
| Requests succeeded / total | 0 / ? | **890 / 890** |
| Retries | — | **0** |
| Wall time | — | **111 s** |
| Unique items scraped | 0 | **16 531** |
| Null `itemId` / `currentPrice` / `currency` / `itemName` / `img` | — | 0 |
| Discounted items | — | 1 345 (8.1%) |
| Weighable items flagged | — | 6 |
| Top-level categories | 0 | 16 |
| `stats.offers` vs dataset size | — | matches exactly |