### PR TITLE
fix(hornbach-daily): do not prepend origin when Apollo item.url is absolute

### DIFF
--- a/actors/hornbach-daily/main.js
+++ b/actors/hornbach-daily/main.js
@@ -36,10 +36,18 @@ const Selectors = {
 };
 
 /**
+ * Resolve a Hornbach link against the localized origin. Accepts both the
+ * legacy relative paths (`/c/...`, `/p/...`) used by the navigation scrape
+ * and the absolute URLs now emitted by the Apollo state for product items
+ * (`https://www.hornbach.cz/p/.../<id>/`). Without the absolute-URL guard
+ * the scraper would concatenate the origin twice, producing malformed
+ * itemUrls that later crash the Keboola uploader in itemSlug()
+ * (TypeError: Cannot read properties of undefined (reading 'parse')).
  * @param {string} country
  * @param {string} path
  */
 function completeUrl(country, path) {
+  if (typeof path === "string" && /^https?:\/\//i.test(path)) return path;
   return `https://www.hornbach.${country.toLowerCase()}${path}`;
 }
 


### PR DESCRIPTION
Fixes #3521. The scrape runs fine, but the upload to Keboola fails with:

```
TypeError: Cannot read properties of undefined (reading 'parse')
```

## Root cause

Hornbach's GraphQL backend now emits **fully-qualified** `item.url` values in the Apollo state (e.g. `https://www.hornbach.cz/p/.../<id>/`) where it previously emitted relative paths. `extractProducts` still calls `completeUrl(country, item.url)`, which unconditionally prepends the localized origin, producing doubled URLs:

```
https://www.hornbach.czhttps://www.hornbach.cz/p/.../<id>/
```

WHATWG URL parses these without throwing — `hostname` becomes `"www.hornbach.czhttps"` — so the malformed value propagates into the Keboola uploader. There, `itemSlug()` calls `shops.get(shopOrigin(url))` → `undefined` (the lookup key is now `"hornbach.czhttps"`, not in the shops map) → `.parse(url)` crashes.

## Fix

One-line guard in `completeUrl` to return absolute URLs untouched (7 lines of explanatory JSDoc around it):

```js
function completeUrl(country, path) {
  if (typeof path === "string" && /^https?:\/\//i.test(path)) return path;
  return `https://www.hornbach.${country.toLowerCase()}${path}`;
}
```

Handles both the legacy relative-href nav scrape and the new absolute-URL product extraction from the same helper.

## Verification

Ran the fixed `extractProducts` against a live Hornbach category page (`barvy-tapety-a-oblozeni-sten/S11536`, 72 products). All checks pass:

```
  PASS  ≥ 60 products extracted
  PASS  every itemUrl matches hornbach.cz /(p|conf)/slug/<id>/ pattern
  PASS  no URL has a doubled origin
  PASS  itemSlug() never throws
  PASS  every itemSlug matches its abstractProductId
  PASS  shopName resolves to "hornbach_cz"
  PASS  shopOrigin resolves to "hornbach.cz"
  PASS  UNFIXED completeUrl still reproduces the exact #3521 error (regression guard)
```

The regression guard confirms the unfixed `completeUrl` still produces exactly the `Cannot read properties of undefined (reading 'parse')` error from the issue, pinning the fix to the reported bug.