### PR TITLE
fix(datart-daily): bypass F5 Bot Defense + repair stale selectors

### DIFF
--- a/actors/datart-daily/Dockerfile
+++ b/actors/datart-daily/Dockerfile
@@ -1,8 +1,13 @@
-FROM apify/actor-node:24
+FROM apify/actor-node-puppeteer-chrome:24
 
 COPY package.json ./
 
 RUN npm --quiet set progress=false \
- && npm install --only=prod --no-optional
+ && npm install --omit=dev --omit=optional --fund=false --audit=false --save=false
+
+# Pre-download the cloakbrowser stealth-Chromium binary (~200 MB) during the
+# image build so the first actor run doesn't pay the download cost. The
+# library caches the binary under $HOME/.cache/cloakbrowser by default.
+RUN node -e "import('cloakbrowser').then(async ({ launch }) => { const b = await launch({ headless: true }); await b.close(); }).catch(e => { console.error(e); process.exit(1); })"
 
 COPY . ./

--- a/actors/datart-daily/main.js
+++ b/actors/datart-daily/main.js
@@ -1,4 +1,4 @@
-import { HttpCrawler, useState } from "@crawlee/http";
+import { BasicCrawler, useState } from "@crawlee/basic";
 import { ActorType } from "@hlidac-shopu/actors-common/actor-type.js";
 import { getInput, restPageUrls } from "@hlidac-shopu/actors-common/crawler.js";
 import { parseHTML, parseXML } from "@hlidac-shopu/actors-common/dom.js";
@@ -6,7 +6,8 @@ import { uploadToKeboola } from "@hlidac-shopu/actors-common/keboola.js";
 import rollbar from "@hlidac-shopu/actors-common/rollbar.js";
 import { withPersistedStats } from "@hckr_/apify-persistent-stats";
 import { Actor, Dataset, log } from "apify";
-import { gotScraping } from "got-scraping";
+import { launchContext as launchCloakContext } from "cloakbrowser";
+import { Impit } from "impit";
 
 /** @typedef {import("linkedom/types/interface/document").Document} Document */
 
@@ -29,12 +30,13 @@ const rootCZ = "https://www.datart.cz";
 const rootSK = "https://www.datart.sk";
 
 async function countAllProducts({ body, stats }) {
-  const { document } = parseXML(body.toString());
+  const { document } = parseXML(body);
   const productXmlUrls = document.querySelectorAll("sitemap loc").map(loc => loc.innerText.trim());
   log.info(`Enqueued ${productXmlUrls.length} product xml urls`);
 
   for (const xmlUrl of productXmlUrls) {
-    const { body } = await gotScraping.get(xmlUrl);
+    const res = await fetch(xmlUrl);
+    const body = await res.text();
     const { document } = parseXML(body);
     let readyForProductsLink = false;
     document.querySelectorAll("url priority").forEach(priority_ => {
@@ -50,6 +52,88 @@ async function countAllProducts({ body, stats }) {
   log.info(`Total items ${stats.get().items}x`);
 }
 
+// ---------------------------------------------------------------------------
+// Solver: cloakbrowser → F5 BIG-IP Bot Defense challenge → TSPD cookies
+// ---------------------------------------------------------------------------
+// Datart is protected by F5 Advanced WAF + Bot Defense. Non-browser HTTP
+// clients (node fetch, got-scraping, curl with OpenSSL TLS) receive a 6.7 KB
+// JS-challenge stub from Apify datacenter IPs. Real Chromium passes the
+// challenge because it executes the /TSPD/?type=12 sensor script, which
+// POSTs back a fingerprint and receives upgraded TS01.../TS25... session
+// cookies. cloakbrowser is a stealth-patched Chromium that passes this
+// challenge headlessly. See topmonks/hlidac-shopu#3520.
+//
+// Inspired by yfe404/turnstile-unblocker: two-phase solver/executor split.
+
+/**
+ * Launch cloakbrowser, navigate to the catalog, poll until F5 issues TSPD
+ * cookies, return the full cookie jar.
+ * @param {string} rootUrl
+ * @returns {Promise<Record<string,string>>}
+ */
+async function solveF5(rootUrl) {
+  log.info("Solver: launching cloakbrowser to solve F5 Bot Defense challenge…");
+  const ctx = await launchCloakContext({
+    headless: true,
+    userAgent:
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
+    locale: "cs-CZ",
+    timezoneId: "Europe/Prague"
+  });
+  try {
+    const page = await ctx.newPage();
+    await page.goto(`${rootUrl}/katalog`, { waitUntil: "domcontentloaded", timeout: 60000 });
+
+    const deadline = Date.now() + 60000;
+    while (Date.now() < deadline) {
+      const jar = await ctx.cookies(rootUrl);
+      const hasTspd = jar.some(c => c.name.startsWith("TS"));
+      const hasBigIp = jar.some(c => c.name.startsWith("BIGipServer"));
+      if (hasTspd && hasBigIp) {
+        const cookies = Object.fromEntries(jar.map(c => [c.name, c.value]));
+        log.info(`Solver: F5 session solved (${jar.length} cookies, TSPD+BIGipServer present)`);
+        return cookies;
+      }
+      await page.waitForTimeout(1000);
+    }
+    throw new Error("Solver: timed out waiting for TSPD cookie from F5");
+  } finally {
+    await ctx.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Executor: impit (chrome136 TLS fingerprint) + solved cookies
+// ---------------------------------------------------------------------------
+// F5 Bot Defense checks the TLS fingerprint on every request, not just the
+// cookies. Got-scraping / node fetch / curl-OpenSSL all present a non-Chrome
+// TLS handshake and get 403 even with valid TSPD cookies. impit is a Rust/
+// napi-rs library that impersonates Chrome 136's TLS handshake from Node,
+// so F5 accepts the cookies as genuinely browser-issued.
+
+/**
+ * Fetch a URL through impit with the solved F5 cookies injected.
+ * @param {Impit} impit
+ * @param {Record<string,string>} cookies
+ * @param {string} url
+ * @returns {Promise<{status: number, body: string}>}
+ */
+async function executorFetch(impit, cookies, url) {
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("; ");
+  const res = await impit.fetch(url, {
+    headers: {
+      Cookie: cookieHeader,
+      Accept:
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+      "Accept-Language": "cs-CZ,cs;q=0.9,en;q=0.8",
+      "Upgrade-Insecure-Requests": "1"
+    }
+  });
+  return { status: res.status, body: await res.text() };
+}
+
 /**
  *
  * @param {Document} document
@@ -58,7 +142,14 @@ async function countAllProducts({ body, stats }) {
  * @returns {Object[]}
  */
 function extractItems(document, rootUrl, country) {
-  const categories = document.querySelectorAll("ol.breadcrumb > li > a").map(a => a.innerText.trim());
+  // Datart's modern breadcrumb uses a BEM-like class (`c-breadcrumb`,
+  // `breadcrumbs`, etc. depending on frontend version), not `ol.breadcrumb`.
+  // Match any element whose class contains "breadcrumb" and drop empty
+  // entries (the home icon link has no text).
+  const categories = document
+    .querySelectorAll('[class*="breadcrumb"] a')
+    .map(a => a.innerText.trim())
+    .filter(t => t.length > 0);
 
   return document
     .querySelectorAll("div.product-box-list div.product-box")
@@ -66,13 +157,29 @@ function extractItems(document, rootUrl, country) {
     .map(productEl => {
       const productBoxTopSide = productEl.querySelector("div.product-box-top-side");
       const productHeader = productBoxTopSide.querySelector("div.item-title-holder h3.item-title a");
-      const productBoxBuyInfoDelivery = productEl.querySelector(
-        "div.product-box-buy-info > div.product-box-buy-info-delivery span.color-text-red"
-      );
+      // Datart list pages advertise availability in several states. We treat
+      // anything the shopper can actually obtain as in-stock — that means not
+      // just "ships immediately" but also "last piece", "at the supplier",
+      // and "available in physical store(s)". Only the two explicit out-of-
+      // stock texts ("Není skladem", "Očekáváme do …") force false.
+      //   Class modifiers on div.product-availability-eshop:
+      //     --inStock   → "Ihned k odeslání"       (ships immediately)
+      //     --lastPiece → "Poslední kus k odeslání" (last piece)
+      //     (bare)      → state text decides       (U dodavatele / Není skladem / Očekáváme do …)
+      //   No eshop element at all → product only available for in-store pickup,
+      //   shown via div.product-availability-reservation ("Skladem v N prodejnách").
+      const availEshopEl = productEl.querySelector("div.product-availability-eshop");
+      const availEshopClass = availEshopEl?.getAttribute("class") || "";
+      const stateText = productEl.querySelector(".product-availability-state")?.textContent?.trim() || "";
+      const storeReservationEl = productEl.querySelector("div.product-availability-reservation");
+      const isExplicitlyOut = /není\s*sklad/i.test(stateText) || /očekáváme/i.test(stateText);
+      const isImmediate = availEshopClass.includes("--inStock");
+      const isLastPiece = availEshopClass.includes("--lastPiece");
+      const isFromSupplier = /u\s*dodavatele/i.test(stateText);
+      const inStock = !isExplicitlyOut && (isImmediate || isLastPiece || isFromSupplier || Boolean(storeReservationEl));
 
       const result = {
-        productBoxBuyInfoDelivery,
-        inStock: Boolean(productBoxBuyInfoDelivery),
+        inStock,
         currency: country === Country.CZ ? "CZK" : "EUR",
         category: categories,
         itemName: productHeader.innerText.trim(),
@@ -161,9 +268,24 @@ function extractItems(document, rootUrl, country) {
     });
 }
 
-function getLastPageNumber(arr) {
-  // first and last buttons are arrows
-  return arr.length > 3 ? Number(arr[arr.length - 2].innerText) : 0;
+/**
+ * Parse pagination page-link `href`s of the form `.../televize.html?page=44`
+ * and return the highest page number, or 0 if there's no pagination. More
+ * robust than the old arrow-position approach because it works regardless of
+ * whether Prev/Next arrows or ellipses are present.
+ * @param {Element[]} links
+ */
+function getLastPageNumber(links) {
+  let max = 0;
+  for (const a of links) {
+    const href = a.getAttribute?.("href") || "";
+    const m = href.match(/[?&]page=(\d+)/);
+    if (m) {
+      const n = Number(m[1]);
+      if (n > max) max = n;
+    }
+  }
+  return max;
 }
 
 function startingRequest({ rootUrl, country, type }) {
@@ -245,30 +367,81 @@ export async function main() {
 
   const rootUrl = country === Country.CZ ? rootCZ : rootSK;
 
-  log.info("ACTOR - setUp crawler");
-  const proxyConfiguration = await Actor.createProxyConfiguration({
-    groups: proxyGroups,
-    useApifyProxy: !development
-  });
+  // Phase 1 — Solver: cloakbrowser earns a validated F5 session
+  let f5Cookies = await solveF5(rootUrl);
 
-  const crawler = new HttpCrawler({
-    proxyConfiguration,
+  // Phase 2 — Executor: impit with chrome136 TLS fingerprint.
+  // Impit impersonates Chrome's TLS handshake from Node, so F5 accepts the
+  // TSPD cookies the solver earned as genuinely browser-issued.
+  log.info("Executor: initializing impit with chrome136 TLS fingerprint");
+  const impit = new Impit({ browser: "chrome136" });
+
+  // F5 burns sessions after ~30–40 requests: instead of returning 403 or the
+  // challenge stub, it silently replies 200 with a decoy body that lacks the
+  // real product grid. We detect that via body signature and re-solve. Only
+  // one re-solve runs at a time (mutex via an in-flight promise) so the 20
+  // concurrent workers don't stampede cloakbrowser.
+  let solvePromise = null;
+  async function triggerResolve(reason) {
+    if (solvePromise) return solvePromise;
+    solvePromise = (async () => {
+      try {
+        log.warning(`F5 re-solve triggered: ${reason}`);
+        f5Cookies = await solveF5(rootUrl);
+      } finally {
+        solvePromise = null;
+      }
+    })();
+    return solvePromise;
+  }
+
+  log.info("ACTOR - setUp crawler");
+  const crawler = new BasicCrawler({
     maxRequestRetries,
-    useSessionPool: true,
-    persistCookiesPerSession: true,
     maxRequestsPerMinute: 100,
     maxConcurrency: 20,
-    sessionPoolOptions: {
-      sessionOptions: {
-        maxUsageCount: 100
+    async requestHandler({ request, log, crawler }) {
+      if (solvePromise) await solvePromise;
+      const { status, body } = await executorFetch(impit, f5Cookies, request.url);
+
+      // Hard block — 403 or the explicit challenge stub.
+      if (status === 403 || (body.includes("/TSPD/") && body.length < 15000)) {
+        stats.inc("blocked");
+        await triggerResolve(`hard block on ${request.url} (status=${status}, ${body.length}b)`);
+        throw new Error("F5 session re-solved, retrying request");
       }
-    },
-    async requestHandler({ request, log, body, session, crawler }) {
+
+      // Silent decoy — 200 OK, but the body lacks the product/category
+      // markers AND is small enough to be an F5 decoy. Observed F5 decoy
+      // bodies cluster at 53–60 KB; legitimate non-product landing pages
+      // (editorial/service pages like /retro-spotrebice, /dtest-*) are
+      // ~1.6 MB. A 100 KB threshold cleanly separates the two clusters,
+      // so we only re-solve on small bodies. The XML sitemap path (COUNT)
+      // is exempt. The marker set covers every product-bearing label:
+      // START → microsite-katalog / category-submenu; CATEGORY →
+      // product-box-list / subcategory-box-list / category-tree-box-list;
+      // BF → ms-category-box; everything deeper carries breadcrumb.
+      if (request.userData.label !== Labels.COUNT) {
+        const looksLikeDatart =
+          body.includes("product-box-list")
+          || body.includes("subcategory-box-list")
+          || body.includes("category-tree-box-list")
+          || body.includes("microsite-katalog")
+          || body.includes("category-submenu")
+          || body.includes("ms-category-box")
+          || body.includes("breadcrumb");
+        if (!looksLikeDatart && body.length < 100_000) {
+          stats.inc("blocked");
+          await triggerResolve(`decoy response on ${request.url} (${body.length}b, no datart markers)`);
+          throw new Error("F5 session re-solved, retrying request");
+        }
+      }
+
       if (request.userData.label === Labels.COUNT) {
         await countAllProducts({ body, stats });
         return;
       }
-      const { document } = parseHTML(body.toString());
+      const { document } = parseHTML(body);
       if (request.userData.label === Labels.START) {
         const urls = document.querySelectorAll("div.microsite-katalog ul.category-submenu > li > a").map(a => ({
           url: `${rootUrl}${a.href}`,
@@ -326,10 +499,13 @@ export async function main() {
           });
           return; // Nothing more we can do for this page
         }
-        // No more categories and subcategories continue with find maxPaginationPage
-        const lastPagination = getLastPageNumber(document.querySelectorAll("div.pagination-wrapper ul.pagination a"));
+        // No more categories and subcategories continue with find maxPaginationPage.
+        // Datart's modern paginator renders `ul.pagination a.page-link` directly
+        // (no `div.pagination-wrapper`) with hrefs like `?page=44`. The legacy
+        // `?showPage&page=N&limit=16` query form is no longer used by the site.
+        const lastPagination = getLastPageNumber(document.querySelectorAll("ul.pagination a.page-link"));
         const urls = restPageUrls(lastPagination, i => ({
-          url: `${request.url}?showPage&page=${i}&limit=16`,
+          url: `${request.url}?page=${i}`,
           userData: {
             label: Labels.CATEGORY_NEXT
           }
@@ -361,11 +537,6 @@ export async function main() {
             stats.inc("itemsDuplicity");
             log.info(`ID ${product.itemId} already saved`);
           }
-        }
-        if (!products.length && !document.querySelector("[data-webname]")) {
-          session.retire();
-          stats.inc("blocked");
-          throw new Error("Looks like we are blocked");
         }
         log.info(`${request.url} Found ${products.length} products`);
       }

--- a/actors/datart-daily/package.json
+++ b/actors/datart-daily/package.json
@@ -6,11 +6,14 @@
   "description": "This is the datart.cz actor.",
   "type": "module",
   "dependencies": {
-    "@crawlee/http": "3.15.3",
+    "@crawlee/basic": "3.16.0",
     "@hckr_/apify-persistent-stats": "1.0.2",
     "@hlidac-shopu/actors-common": "3.2.4",
     "apify": "3.5.3",
-    "got-scraping": "4.1.3"
+    "cloakbrowser": "^0.3.19",
+    "impit": "^0.13.0",
+    "impit-linux-x64-gnu": "^0.13.0",
+    "playwright-core": "^1.59.1"
   },
   "devDependencies": {
     "@types/node": "24.10.4",


### PR DESCRIPTION
Fixes topmonks/hlidac-shopu#3520.

Datart is protected by F5 BIG-IP Advanced WAF + Bot Defense. From any
non-browser HTTP client (got-scraping, node fetch, curl with OpenSSL TLS)
the `/katalog` root returns a 6.7 KB JS-challenge stub with a `/TSPD/?type=12`
sensor script and a `support ID: 14841702856302622154` noscript gate, so
`@crawlee/http`'s HttpCrawler had been silently scraping the challenge HTML
and producing 0 items in production. In addition, several list-page
selectors had drifted against the live DOM, masking data-quality issues
that went unnoticed while the block-page fallback dominated the output.

Verification run on Apify (`straightforward_understanding/datart-cz`):
https://console.apify.com/actors/09913yZuQWxKyTEe0/runs/UnzTBCfVicdefX6no#output

## Bot Defense handling

Replaces HttpCrawler with a two-phase solver/executor architecture:

* **Solver** (`solveF5`): `cloakbrowser` — a stealth-patched Chromium with
  drop-in Playwright API — navigates `/katalog`, lets F5's `/TSPD/?type=12`
  sensor POST back a fingerprint, polls the cookie jar until both a
  `TSPD…` and a `BIGipServer…` cookie are present, then returns the full
  jar (~12 cookies).
* **Executor** (`executorFetch`): `impit` (Rust/napi-rs) impersonates the
  Chrome 136 TLS handshake from Node. F5 checks the TLS fingerprint on
  every request, not just cookies — plain Node.js fetch or curl-OpenSSL
  gets 403 even with a valid cookie jar. Injects the solved cookies via
  `Cookie:` header.
* **Burn detection + mutex'd re-solve**: F5 burns a cookie set after
  ~30–40 requests. The burn is silent — 200 OK with a ~57 KB decoy body
  that lacks the product grid (not a 403, not the challenge stub). An
  explicit body-signature check catches it: if no Datart page marker
  (`product-box-list`, `category-submenu`, `breadcrumb`, etc.) AND the
  body is < 100 KB (to exclude legitimate editorial landing pages like
  `/retro-spotrebice`, `/dtest-*` at ~1.6 MB), trigger a re-solve. A
  single in-flight `solvePromise` serialises concurrent re-solves so 20
  workers don't stampede cloakbrowser. Same-IP re-solves work as long as
  cloakbrowser re-executes the sensor script, so the scraper runs over
  Apify's datacenter egress without residential proxy.
* Dockerfile switches from `apify/actor-node:24` (Alpine/musl) to
  `apify/actor-node-puppeteer-chrome:24` (Debian/glibc) because
  `cloakbrowser` and `impit-linux-x64-gnu` ship glibc-only prebuilds, and
  pre-downloads the ~200 MB stealth Chromium binary at image build time.

## Stale selector repairs

All verified against the live list-page DOM via cloakbrowser:

* **Breadcrumb**: `ol.breadcrumb > li > a` no longer exists on the modern
  frontend; `category` was always serialised as `[]`. Switched to
  `[class*="breadcrumb"] a` and filter empty text nodes (home-icon link).
* **`inStock`**: the legacy check `span.color-text-red` was both stale
  (the class no longer appears on product boxes) and inverted (red text
  historically marked *unavailable* items). The new frontend uses four
  list-page availability states; treat all obtainable variants as in
  stock:
  - `--inStock`            → "Ihned k odeslání"        (ships immediately) ✓
  - `--lastPiece`          → "Poslední kus k odeslání" (last piece)        ✓
  - bare class + `U dodavatele` text                (at supplier)          ✓
  - no eshop element + store-pickup element         (in physical stores)   ✓
  - bare class + `Není skladem` / `Očekáváme do …` text                    ✗
* **Pagination**: `div.pagination-wrapper` no longer wraps the paginator;
  the old selector matched 0 elements and every leaf silently scraped
  only page 1 (the full catalog run landed at ~14 k items instead of the
  expected ~40–60 k). The new selector is `ul.pagination a.page-link` and
  the URL template is simplified from the legacy `?showPage&page=N&limit=16`
  to the site's own `?page=N`. `getLastPageNumber()` now extracts the
  highest page number from the href regex, which is robust to ellipses
  and Prev/Next arrows appearing or disappearing.
* Dropped the serialised DOM element `productBoxBuyInfoDelivery` from the
  result object — it was always `null` after JSON serialisation anyway.
