### PR TITLE
fix(iglobus-daily): migrate to globusonline.cz rebrand

### DIFF
--- a/actors/iglobus-daily/main.js
+++ b/actors/iglobus-daily/main.js
@@ -1,16 +1,19 @@
-import { URL } from "url";
 import { HttpCrawler, useState } from "@crawlee/http";
 import { ActorType } from "@hlidac-shopu/actors-common/actor-type.js";
 import { getInput, restPageUrls } from "@hlidac-shopu/actors-common/crawler.js";
-import { parseHTML } from "@hlidac-shopu/actors-common/dom.js";
 import { uploadToKeboola } from "@hlidac-shopu/actors-common/keboola.js";
 import { saveUniqProducts } from "@hlidac-shopu/actors-common/product.js";
-import { cleanPriceText, cleanUnitPriceText } from "@hlidac-shopu/actors-common/product.js";
 import rollbar from "@hlidac-shopu/actors-common/rollbar.js";
 import { withPersistedStats } from "@hckr_/apify-persistent-stats";
-import { Actor, KeyValueStore, LogLevel, log } from "apify";
+import { Actor, LogLevel, log } from "apify";
 
-const rootUrl = "https://shop.iglobus.cz";
+// iGlobus rebranded to globusonline.cz in early 2026. Every shop.iglobus.cz
+// URL now 301-redirects to globusonline.cz, and the old /store/switch endpoint
+// returns 404 on the new site. The new site is a Next.js React app that
+// exposes all category and product data via a urqlState GraphQL cache embedded
+// in <script id="__NEXT_DATA__">, so scraping is JSON parsing, not DOM.
+const rootUrl = "https://globusonline.cz";
+const CATEGORY_PAGE_SIZE = 60; // edges per page in the ProductConnection response
 
 /** @enum {string} */
 const Labels = {
@@ -19,64 +22,158 @@ const Labels = {
   COUNT: "COUNT"
 };
 
-/** @enum {string} */
-const Stores = {
-  ZLI: "ZLI",
-  OST: "OST"
-};
-
-function extractItems(document, category) {
-  return document.querySelectorAll(".product-list product-item").map(product => {
-    const result = { inStock: true };
-    result.itemId = product.querySelector(".add-to-cart-btn a").getAttribute("data-product-id");
-    result.itemName = product.querySelector("div.product-item__info > a").innerText.trim();
-    result.itemUrl = extractProductUrl(product.querySelector("div.product-item__info > a").getAttribute("onclick"));
-    result.img = product.querySelector(".image-link img").getAttribute("src");
-
-    const currentPrice =
-      product.querySelector(".money-price span.money-price__amount-discount")?.innerText?.trim() ??
-      product.querySelector(".money-price span.money-price__amount")?.innerText?.trim();
-
-    if (currentPrice === null || currentPrice === undefined) {
-      throw new Error("Could not find current price");
-    }
-
-    result.currentPrice = parseFloat(cleanPriceText(currentPrice));
-    const originalPrice = product.querySelector(".money-price__amount--original")?.innerText?.trim();
-    result.originalPrice = originalPrice ? parseFloat(cleanPriceText(originalPrice)) : null;
-    result.currentUnitPrice = parseFloat(
-      cleanUnitPriceText(product.querySelector(".product-item__sale-volume").innerText.trim())
-    );
-    result.useUnitPrice = product.querySelector(".product-item__info").innerText.includes("cca");
-    result.discounted = result.currentPrice < result.originalPrice;
-    result.currency = "CZK";
-    result.category = category;
-    return result;
-  });
+/**
+ * Extract and JSON-parse the Next.js SSR data blob. Every page on
+ * globusonline.cz embeds one; returns null if the tag is missing (e.g.
+ * if the actor was pointed at an error page).
+ * @param {string} html
+ */
+function parseNextData(html) {
+  const match = /<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/.exec(html);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
 }
 
-function extractProductUrl(onclickAttr) {
-  if (!onclickAttr) return null;
-  const regexp = /\'(\S+)\'/m;
-  const match = regexp.exec(onclickAttr);
-  return `${rootUrl}${match[1]}`;
+/**
+ * Walk the urqlState cache and find a query result whose parsed data has a
+ * given top-level key. Each cache entry has a stringified `data` field.
+ * @returns {object|null}
+ */
+function findUrqlQuery(nextData, topKey) {
+  const urql = nextData?.props?.pageProps?.urqlState;
+  if (!urql) return null;
+  for (const entry of Object.values(urql)) {
+    if (!entry?.data) continue;
+    try {
+      const parsed = typeof entry.data === "string" ? JSON.parse(entry.data) : entry.data;
+      if (parsed && parsed[topKey] != null) return parsed;
+    } catch {
+      /* skip */
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract top-level category URLs from the homepage. Reads the `categories`
+ * query out of the Next.js urqlState — every entry is a category object with
+ * a `slug` field that's already a relative path like "/k/pekarna-a-cukrarna".
+ * @param {string} html
+ * @returns {string[]} absolute category URLs
+ */
+function topCategoryUrls(html) {
+  const data = parseNextData(html);
+  const q = findUrqlQuery(data, "categories");
+  if (!q?.categories) {
+    // Fallback: regex over the raw HTML for /k/<slug> hrefs on the homepage.
+    // Used if Next.js ever ships the page without the categories query
+    // (e.g. a CMS-driven variant) so the actor keeps working.
+    const seen = new Set();
+    for (const m of html.matchAll(/href="(\/k\/[a-z0-9-]+)"/g)) {
+      seen.add(m[1]);
+    }
+    return [...seen].map(p => `${rootUrl}${p}`);
+  }
+  return q.categories.map(c => `${rootUrl}${c.slug}`);
+}
+
+/**
+ * Parse a price string like "3.900000" or "3900.00" into a plain number.
+ * globusonline.cz stores prices as strings with six decimal places.
+ */
+function parsePrice(s) {
+  if (s == null) return null;
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Extract the products on a category page from the urqlState cache. Returns
+ * an array of product objects in the same output shape the old DOM-based
+ * extractItems() produced.
+ * @param {string} html
+ * @param {string} categoryName human-readable category label for the row
+ */
+function extractItems(html, categoryName) {
+  const data = parseNextData(html);
+  const q = findUrqlQuery(data, "products");
+  const edges = q?.products?.edges;
+  if (!Array.isArray(edges)) return [];
+
+  return edges
+    .map(edge => {
+      const p = edge.node;
+      if (!p || p.isSellingDenied) return null;
+      const price = p.price ?? {};
+      const currentPrice = parsePrice(price.priceWithVat);
+      if (currentPrice == null) return null;
+
+      const originalPrice = parsePrice(price.globusOriginalPrice);
+      const baseComparison = parsePrice(price.baseComparisonPrice);
+
+      return {
+        itemId: p.id != null ? String(p.id) : p.uuid,
+        itemName: p.fullName ?? p.name,
+        itemUrl: `${rootUrl}${p.slug}`,
+        img: p.mainImage?.url ?? null,
+        currentPrice,
+        originalPrice: originalPrice && originalPrice > currentPrice ? originalPrice : null,
+        currentUnitPrice: baseComparison,
+        useUnitPrice: p.productArticleType === "WEIGHT_PRODUCT",
+        discounted: originalPrice != null && originalPrice > currentPrice,
+        currency: "CZK",
+        category: categoryName,
+        inStock: p.availability?.status === "InStock"
+      };
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Read the total product count for the current category page from the same
+ * urqlState `category` query that carries taxonomy metadata. Used to compute
+ * the pagination fan-out.
+ * @param {string} html
+ */
+function extractCategoryTotal(html) {
+  const data = parseNextData(html);
+  // The `category` query is a separate urql entry from `products`, but both
+  // live in the same urqlState map.
+  const urql = data?.props?.pageProps?.urqlState;
+  if (!urql) return { total: 0, name: "" };
+  for (const entry of Object.values(urql)) {
+    if (!entry?.data) continue;
+    try {
+      const parsed = typeof entry.data === "string" ? JSON.parse(entry.data) : entry.data;
+      if (parsed?.category?.products?.totalCount != null) {
+        return {
+          total: parsed.category.products.totalCount,
+          name: parsed.category.name ?? ""
+        };
+      }
+    } catch {
+      /* skip */
+    }
+  }
+  return { total: 0, name: "" };
 }
 
 async function main() {
   rollbar.init();
-  const { development, maxRequestRetries, proxyGroups, store = Stores.ZLI, type = ActorType.Full } = await getInput();
+  const { development, maxRequestRetries, proxyGroups, type = ActorType.Full } = await getInput();
 
   const processedIds = await useState("processedIds", {});
-  const stats = await withPersistedStats(
-    x => x,
-    (await KeyValueStore.getValue("STATS")) || {
-      categories: 0,
-      pages: 0,
-      items: 0,
-      itemsDuplicity: 0,
-      countItems: 0
-    }
-  );
+  const stats = await withPersistedStats({
+    categories: 0,
+    pages: 0,
+    items: 0,
+    itemsDuplicity: 0,
+    countItems: 0
+  });
 
   if (development) {
     log.setLevel(LogLevel.DEBUG);
@@ -92,85 +189,59 @@ async function main() {
     maxRequestRetries,
     maxRequestsPerMinute: 600,
     async requestHandler({ crawler, request, body }) {
-      const { document } = parseHTML(body.toString());
+      const html = body.toString();
       const { url, userData } = request;
       const { label, category } = userData;
       log.info("Page opened.", { label, category, url });
+
       switch (label) {
-        case Labels.START:
+        case Labels.START: {
+          const categoryUrls = topCategoryUrls(html);
+          log.info(`Found ${categoryUrls.length}x categories`);
           if (type === ActorType.Count) {
-            const requests = document
-              .querySelectorAll("a.navigation-multilevel-node__link-inner--lvl-2")
-              .map(countLink => {
-                const url = new URL(countLink.getAttribute("href"), rootUrl);
-                if (!url.toString().includes("novinky")) {
-                  return {
-                    url: `${url.href}`,
-                    userData: {
-                      label: Labels.COUNT,
-                      category: countLink.innerText.trim()
-                    }
-                  };
-                }
-              });
+            const requests = categoryUrls.map(u => ({
+              url: u,
+              userData: { label: Labels.COUNT, category: u.substring(u.lastIndexOf("/") + 1) }
+            }));
             await crawler.requestQueue.addRequests(requests);
           } else {
-            const requests = document
-              .querySelectorAll(
-                ".menu > li.filter-category__item--level-2 > button.filter-category__link, " +
-                  ".menu > li.filter-category__item--level-2 > div > div > button.filter-category__link, " +
-                  ".menu > li.filter-category__item--level-3 > button.filter-category__link, " +
-                  ".menu > li.filter-category__item--level-3 > div > div > button.filter-category__link"
-              )
-              .map(link => {
-                const url = new URL(link.getAttribute("data-url"), rootUrl);
-                return {
-                  url: `${url.href}`,
-                  userData: {
-                    label: Labels.LIST,
-                    page: 0,
-                    category: link.innerText.trim()
-                  }
-                };
-              });
+            const requests = categoryUrls.map(u => ({
+              url: u,
+              userData: { label: Labels.LIST, page: 1, category: u.substring(u.lastIndexOf("/") + 1) }
+            }));
             stats.add("categories", requests.length);
-            log.info(`Found ${requests.length}x categories`);
             await crawler.requestQueue.addRequests(requests);
           }
           break;
-        case Labels.LIST:
+        }
+
+        case Labels.LIST: {
           stats.inc("pages");
-          if (userData.page === 0) {
-            const lastPageLink =
-              document
-                .querySelectorAll(".pagination .pagination__step-cz:not(.pagination__step--next-cz)")
-                .at(-1)
-                ?.getAttribute("href") ?? "";
-
-            const paginationLink = new URL(lastPageLink, rootUrl);
-            const pagesTotal = paginationLink.searchParams.get("page");
-            const requests = restPageUrls(pagesTotal, i => {
-              paginationLink.searchParams.set("page", i.toString());
-              userData.page = i;
-              return {
-                url: paginationLink.href,
-                userData
-              };
-            });
-            await crawler.requestQueue.addRequests(requests, {
-              forefront: true
-            });
+          if (userData.page === 1) {
+            const { total, name } = extractCategoryTotal(html);
+            if (name) userData.category = name;
+            const pagesTotal = Math.ceil(total / CATEGORY_PAGE_SIZE);
+            if (pagesTotal > 1) {
+              const requests = restPageUrls(pagesTotal, i => ({
+                url: `${url}?page=${i}`,
+                userData: { label: Labels.LIST, page: i, category: userData.category }
+              }));
+              await crawler.requestQueue.addRequests(requests, { forefront: true });
+            }
           }
-
-          const products = extractItems(document, userData.category);
+          const products = extractItems(html, userData.category);
           log.info(`Found ${products.length} products`);
           await saveUniqProducts({ products, stats, processedIds });
           break;
-        case Labels.COUNT:
-          const count = document("span.category-number-of-products").innerText.trim().match(/\d+/)[0];
-          stats.add("countItems", Number(count));
-          log.info(`Found ${count} items in category ${request.userData.category}`);
+        }
+
+        case Labels.COUNT: {
+          const { total } = extractCategoryTotal(html);
+          stats.add("countItems", total);
+          log.info(`Found ${total} items in category ${userData.category}`);
           break;
+        }
+
         default:
           log.error(`Unknown label ${label}`);
       }
@@ -181,21 +252,18 @@ async function main() {
   });
 
   const startingRequests = [];
-  if (type === ActorType.Full) {
+  if (type === ActorType.Full || type === ActorType.Count) {
     startingRequests.push({
-      url: `${rootUrl}/store/switch?store=${store}&referer-url=/cs/outlet`,
+      url: `${rootUrl}/`,
       userData: { label: Labels.START }
     });
   } else if (type === ActorType.Test) {
     startingRequests.push({
-      url: `https://shop.iglobus.cz/cs/sv%C4%9Bt-d%C4%9Bt%C3%AD/d%C4%9Btsk%C3%A1-v%C3%BD%C5%BEiva/p%C5%99%C3%ADkrmy/ovocn%C3%A9`,
-      userData: {
-        label: Labels.LIST,
-        page: 0,
-        category: "Ovocné"
-      }
+      url: `${rootUrl}/k/pekarna-a-cukrarna`,
+      userData: { label: Labels.LIST, page: 1, category: "Pekárna a cukrárna" }
     });
   }
+
   log.info("Starting the crawl.");
   await crawler.run(startingRequests);
   log.info("Crawl finished.");

--- a/lib/shops.mjs
+++ b/lib/shops.mjs
@@ -382,10 +382,10 @@ const hornbachSk = {
 };
 
 const iGlobusCz = {
-  name: "iGlobus.cz",
+  name: "Globus Online",
   currency: "CZK",
   logo: "iglobus_logo",
-  url: "https://shop.iglobus.cz/",
+  url: "https://www.globusonline.cz/",
   viewBox: "0 0 1236.8 779.8",
   /** @param {URL} url */
   parse(url) {
@@ -959,6 +959,7 @@ export const shops = new Map([
   ["iglobus", iGlobusCz],
   ["globus_cz", iGlobusCz],
   ["iglobus.cz", iGlobusCz],
+  ["globusonline.cz", iGlobusCz],
   ["ikea_cz", ikeaCz],
   ["ikea.cz", ikeaCz],
   ["ikea_sk", ikeaSk],


### PR DESCRIPTION
Fixes topmonks/hlidac-shopu#3522.

iGlobus rebranded to globusonline.cz. `shop.iglobus.cz` now 301-redirects to `globusonline.cz`, but the old DOM schema the actor relied on (`.menu__link--filter-category`, `.product-list product-item`, `.money-price*`, `.pagination__step-cz`, the `onclick` URL regex, …) no longer exists on the new site.

**Scraper rewrite.** The new site is a Next.js React app with the full urql GraphQL cache embedded in `<script id="__NEXT_DATA__">` on every page. Rewrote `iglobus-daily` to pull products from that JSON cache (`products` ProductConnection, 60 edges/page, with id, slug, fullName, mainImage, price, availability, categories, brand) instead of scraping the DOM. Pagination derived from `category.products.totalCount / 60`. Top-level categories listed from the homepage's `categories` query. Output schema unchanged.

Other migration fallout: `rootUrl` → `globusonline.cz`, start URL → `/` (the old `/store/switch` 404s on the new site), `Stores` enum dropped (new site has a single global catalog, not per-store URLs — `store` input is silently ignored for task-config compat), `withPersistedStats` signature updated. Keboola table `globus_cz` unchanged.

**Registry fix.** The scraper rewrite alone wasn't enough — the uploader still crashed with `Cannot read properties of undefined (reading 'parse')` at `itemSlug`, because `lib/shops.mjs` only knew about `shop.iglobus.cz`. Added `globusonline.cz` as a lookup key pointing at the existing `iGlobusCz` entry (the existing `/[^/]+/([^/]+)$` regex still matches `/p/<slug>` unchanged) and updated the `iGlobusCz.name` / `.url` metadata to the new brand.

Verified on Apify: https://console.apify.com/actors/0VEiJUpg4VKUzFoYG/runs/87N0N3o8ItmCCenX3#output