### PR TITLE
#3550 - Hide Smarty.cz and TSBohemia.cz from homepage and extension about page

### DIFF
--- a/extension/popup/about.html
+++ b/extension/popup/about.html
@@ -153,7 +153,6 @@
     <li>Tchibo.cz</li>
     <li>Tchibo.sk</li>
     <li>TetaDrogerie.cz</li>
-    <li>TSBohemia.cz</li>
   </ul>
   <img src="graf.svg" alt="Ukázka grafu" />
   <p class="powered">

--- a/lib/shops.mjs
+++ b/lib/shops.mjs
@@ -821,6 +821,7 @@ const smartyCz = {
   currency: "CZK",
   logo: "smarty_logo",
   url: "https://www.smarty.cz",
+  show: false,
   viewBox: "0 0 178 30",
   /** @param {URL} url */
   parse(url) {
@@ -890,6 +891,7 @@ const tsbohemiaCz = {
   currency: "CZK",
   logo: "tsbohemia_logo",
   url: "https://www.tsbohemia.cz/",
+  show: false,
   viewBox: "0 0 115 15",
   /** @param {URL} url */
   parse(url) {


### PR DESCRIPTION
Both shops are no longer monitored. Set `show: false` on their shop definitions in `lib/shops.mjs` so they no longer appear in the homepage logo grid, and removed TSBohemia.cz from the supported-shops list in `extension/popup/about.html`.