### PR TITLE
Clear chart reference after cleanup

### DIFF
--- a/extension/content.mjs
+++ b/extension/content.mjs
@@ -111,7 +111,10 @@ function handleDetail(shop) {
     },
     cleanup() {
       renderRoot.remove();
-      if (chart) chart.destroy();
+      if (chart) {
+        chart.destroy();
+        chart = null;
+      }
       shop.loaded = false;
     },
     isRendered() {


### PR DESCRIPTION
## Summary
- Always destroy the existing Chart.js instance before rendering a new chart.
- Reset the chart reference during cleanup.
- Prevent stale canvas/chart state after SPA product-detail rerenders.

## Testing
- yarn workspace @hlidac-shopu/lib test
- yarn run lint:extension
- yarn run build:extension
- git diff --check