### PR TITLE
Fix Rohlik product detail scraping

### DIFF
--- a/extension/shops/rohlik.mjs
+++ b/extension/shops/rohlik.mjs
@@ -67,10 +67,13 @@ const cleanRohlikPrice = selector => {
 
   const cents = elem.querySelector("sup")?.textContent?.replace(/\D/g, "");
   if (cents) {
+    // Cents live in a <sup>; parse the crowns from the rest of the element.
+    // Do not fall back to cleanPrice(elem) here — it would include the sup
+    // digits and yield a 100× price (e.g. "2990" instead of "29.90").
     const withoutCents = elem.cloneNode(true);
     withoutCents.querySelectorAll("sup").forEach(x => x.remove());
     const crowns = cleanPrice(withoutCents);
-    if (crowns) return `${crowns}.${cents.slice(0, 2).padEnd(2, "0")}`;
+    return crowns ? `${crowns}.${cents.slice(0, 2).padEnd(2, "0")}` : null;
   }
 
   return cleanPrice(elem);

--- a/extension/shops/rohlik.mjs
+++ b/extension/shops/rohlik.mjs
@@ -1,11 +1,99 @@
-import { cleanPrice, cleanUnitPrice, isUnitPrice, registerShop } from "../helpers.mjs";
+import { cleanPrice, cleanUnitPrice, getItemIdFromUrl, isUnitPrice, registerShop } from "../helpers.mjs";
 import { StatefulShop } from "./shop.mjs";
 
-const didRenderDetail = mutations => mutations.find(x => Array.from(x.addedNodes).find(y => y.id === "productDetail"));
+const injectionTargets = [
+  ["beforeend", '#productDetail div[data-test="product-detail-upper-section"] > div:last-child'],
+  ["afterend", '#productDetail [data-test="product-detail-price-section"]']
+];
+
+const didRenderDetail = mutations =>
+  mutations.find(x =>
+    Array.from(x.addedNodes).find(
+      y =>
+        y.id === "productDetail" ||
+        y.querySelector?.("#productDetail") ||
+        y.querySelector?.('[data-test="product-detail-upper-section"]')
+    )
+  );
+
+const isProductLd = data => {
+  const type = data?.["@type"];
+  return type === "Product" || (Array.isArray(type) && type.includes("Product"));
+};
+
+const findProductLd = data => {
+  if (!data) return null;
+  if (Array.isArray(data)) return data.map(findProductLd).find(Boolean) ?? null;
+  if (isProductLd(data)) return data;
+  if (data["@graph"]) return findProductLd(data["@graph"]);
+  return null;
+};
+
+const parseProductLd = () => {
+  for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
+    try {
+      const product = findProductLd(JSON.parse(script.textContent));
+      if (product) return product;
+    } catch {}
+  }
+  return null;
+};
+
+const priceFromProductLd = product => {
+  const offers = Array.isArray(product?.offers) ? product.offers[0] : product?.offers;
+  const price = offers?.price ?? offers?.lowPrice;
+  if (price === undefined || price === null) return null;
+
+  const number = Number(String(price).replace(",", "."));
+  return Number.isFinite(number) ? number.toFixed(2) : String(price);
+};
+
+const imageFromProductLd = product => {
+  const image = Array.isArray(product?.image) ? product.image[0] : product?.image;
+  if (!image) return undefined;
+  if (typeof image !== "string") return image.url;
+  if (image.startsWith("http")) return image;
+  if (image.startsWith("//")) return `${location.protocol}${image}`;
+  if (image.startsWith("/"))
+    return `https://www.rohlik.cz/cdn-cgi/image/f=auto,w=500,h=500/https://cdn.rohlik.cz${image}`;
+  return image;
+};
+
+const textFrom = selector => document.querySelector(selector)?.textContent?.trim();
+
+const cleanRohlikPrice = selector => {
+  const elem = typeof selector === "string" ? document.querySelector(selector) : selector;
+  if (!elem) return null;
+
+  const cents = elem.querySelector("sup")?.textContent?.replace(/\D/g, "");
+  if (cents) {
+    const withoutCents = elem.cloneNode(true);
+    withoutCents.querySelectorAll("sup").forEach(x => x.remove());
+    const crowns = cleanPrice(withoutCents);
+    if (crowns) return `${crowns}.${cents.slice(0, 2).padEnd(2, "0")}`;
+  }
+
+  return cleanPrice(elem);
+};
+
+const cleanOriginalPrice = () => {
+  const elem =
+    document.querySelector('#productDetail [data-test="product-detail-price-section-sale"]') ??
+    document.querySelector('#productDetail [data-test="product-in-sale-original"] del') ??
+    document.querySelector("#productDetail del");
+  if (!elem) return null;
+
+  if (isUnitPrice(elem)) {
+    const quantity = cleanPrice("#productDetail .detailQuantity");
+    if (quantity) return cleanUnitPrice(elem, quantity);
+  }
+
+  return cleanRohlikPrice(elem);
+};
 
 export class Rohlik extends StatefulShop {
   get injectionPoint() {
-    return ["beforeend", '#productDetail div[data-test="product-detail-upper-section"] > div:last-child'];
+    return injectionTargets[0];
   }
 
   get detailSelector() {
@@ -24,40 +112,49 @@ export class Rohlik extends StatefulShop {
     return this.didMutate(mutations, "removedNodes", "product_detail_modal");
   }
 
+  inject(renderMarkup) {
+    for (const [position, selector] of injectionTargets) {
+      const elem = document.querySelector(selector);
+      if (!elem) continue;
+      elem.insertAdjacentElement(position, renderMarkup());
+      return elem;
+    }
+    throw new Error(
+      `Element to add chart not found; selectors: ${injectionTargets.map(([, selector]) => selector).join(", ")}`
+    );
+  }
+
   async scrape() {
     const elem = document.querySelector("#productDetail");
     if (!elem) return null;
 
-    const originalPrice = isUnitPrice("#productDetail del")
-      ? cleanUnitPrice("#productDetail del", cleanPrice("#productDetail .detailQuantity"))
-      : cleanPrice("#productDetail del");
+    const url = new URL(window.location.href);
+    const originalPrice = cleanOriginalPrice();
+    const productLd = parseProductLd();
+    const itemIdFromUrl = getItemIdFromUrl(url);
 
-    const jsonld = elem.querySelector('script[type="application/ld+json"]');
-    if (jsonld) {
-      try {
-        const data = JSON.parse(jsonld.innerText);
-        return {
-          itemId: data.sku,
-          title: data.name,
-          currentPrice: data.offers.price.toFixed(2),
-          imageUrl: `https://www.rohlik.cz/cdn-cgi/image/f=auto,w=500,h=500/https://cdn.rohlik.cz${data.image[0]}`,
-          originalPrice
-        };
-      } catch (e) {
-        console.error("Could not find product info", e);
-      }
-    }
+    const itemId = itemIdFromUrl ?? elem.querySelector("button[data-product-id]")?.dataset.productId ?? productLd?.sku;
+    const title =
+      textFrom('#productDetail [data-test="product-detail-product-name"]') ??
+      textFrom("#productDetail h1") ??
+      productLd?.name ??
+      document.title.split("-")[0].trim();
+    const currentPrice =
+      cleanRohlikPrice(
+        // Xtra/Premium member prices are rendered as product-price when active.
+        // premium-priceForPremiumInDetail is an inactive-sale upsell block.
+        `#productDetail [data-test="product-detail-price-section-priceNo"],
+         #productDetail [data-test="product-price"],
+         #productDetail .actionPrice,
+         #productDetail .currentPrice`
+      ) ?? priceFromProductLd(productLd);
+    const imageUrl =
+      elem.querySelector("[data-gtm-item=product-image] img")?.src ??
+      document.querySelector('meta[property="og:image"]')?.content ??
+      imageFromProductLd(productLd);
 
-    const itemId = document.querySelector("#productDetail button[data-product-id]").dataset.productId;
-    const title = document.title.split("-");
-    const t = title[0].trim();
-    const currentPrice = cleanPrice(
-      `#productDetail .actionPrice,
-       #productDetail .currentPrice`
-    );
-    const imageUrl = document.querySelector("[data-gtm-item=product-image] img").src;
-
-    return { itemId, title: t, currentPrice, originalPrice, imageUrl };
+    if (!itemId || !title || !currentPrice) return null;
+    return { itemId, title, currentPrice, originalPrice, imageUrl };
   }
 }
 

--- a/lib/shops.test.mjs
+++ b/lib/shops.test.mjs
@@ -92,6 +92,8 @@ describe("Shops", () => {
       ["https://www.megapixel.cz/jjc-stereo-mikrofon-sgm-185ii", "jjc-stereo-mikrofon-sgm-185ii"],
       ["https://www.luxor.cz/product/ma-cesta-za-stestim-zbo000418126", "ma-cesta-za-stestim-zbo000418126"],
       ["https://shop.iglobus.cz/cz/schubert-erstv-vejce-m-30-ks/8594032850525", "8594032850525"],
+      ["https://www.rohlik.cz/1357409-mleko-polotucne-1-5", "1357409"],
+      ["https://www.rohlik.cz/?productPopup=1357409-mleko-polotucne-1-5", "1357409"],
       [
         "https://www.4camping.cz/p/cepice-sensor-merino-wool/#54-58-cm-cerna",
         "cepice-sensor-merino-wool-54-58-cm-cerna"


### PR DESCRIPTION
## Summary
- Add current Rohlik.cz product-detail selectors and fallback injection targets.
- Parse current Rohlik price markup where cents are rendered in a sup element.
- Prefer URL/current DOM data over potentially stale JSON-LD during SPA navigation.
- Add Rohlik item id parsing coverage for direct product URLs and productPopup URLs.

Fixes #3555

## Testing
- yarn workspace @hlidac-shopu/lib test
- yarn run lint:extension
- yarn run build:extension
- git diff --check