### PR TITLE
fix(dm-daily): adapt to dmtech API changes so DM.cz returns results again

### DIFF
--- a/actors/dm-daily/main.js
+++ b/actors/dm-daily/main.js
@@ -44,7 +44,9 @@ function getCountrySlug(country) {
 }
 
 function makeListingUrl(countryCode, productQuery, currentPage, pageSize = 100) {
-  return `https://product-search.services.dmtech.com/${countryCode.toLowerCase()}/search/static?${new URLSearchParams({
+  // The `/search/static` endpoint now 302-redirects to `/search/crawl`; hit
+  // the new path directly so we don't depend on redirect-following.
+  return `https://product-search.services.dmtech.com/${countryCode.toLowerCase()}/search/crawl?${new URLSearchParams({
     ...productQuery,
     pageSize,
     currentPage,
@@ -101,9 +103,12 @@ function parseItem(item, country, category) {
   // https://products.dm.de/availability/api/v1/tiles/CZ/<id>
   // Not necessary to make the extra call. But the Keboola table schema
   // requires it, so we include it (set to null)
+  // `title.preheadline` (the brand prefix) was dropped from the tile schema;
+  // the brand now lives on the product (`brandName`) / tile (`brand.name`).
+  const brand = p.title.preheadline ?? item.brandName ?? p.brand?.name;
   return {
     itemId: p.gtin,
-    itemName: `${p.title.preheadline} ${p.title.tileHeadline}`,
+    itemName: [brand, p.title.tileHeadline].filter(Boolean).join(" "),
     itemUrl: createProductUrl(country, p.self),
     img: p.images[0]?.tileSrc ?? null,
     inStock: null,
@@ -206,10 +211,13 @@ function categoriesListing({ type, navigation }, stats, country) {
   for (const category of traverseCategories(children)) {
     log.debug(`Found category ${category.title} at link: ${category.link}`);
     stats.inc("categories");
+    // Navigation now ships absolute category links (https://www.dm.cz/<path>);
+    // the content API still expects just the path segment appended to the base.
+    const link = new URL(category.link, "https://www.dm.cz").pathname;
     // we need to await here to prevent higher categories
     // to be enqueued sooner than sub-categories
     requests.push({
-      url: `https://content.services.dmtech.com/rootpage-dm-shop-${getCountrySlug(country)}${category.link}/`,
+      url: `https://content.services.dmtech.com/rootpage-dm-shop-${getCountrySlug(country)}${link}/`,
       userData: {
         country,
         category: category.breadcrumbs.toString(),


### PR DESCRIPTION
## What

The DM.cz daily actor (`actors/dm-daily`) was finishing SUCCESS with 0 items. Three independent dmtech API changes broke it:

1. **Category links are now absolute URLs.** The navigation API ships `https://www.dm.cz/<path>` instead of a path. The actor concatenated that onto the content-API base (`…/rootpage-dm-shop-cs-cz${link}/`), producing a malformed URL → HTTP 400 on every category → no product queries enqueued → 0 items. Fixed by taking the link's `pathname`.
2. **Product search endpoint moved.** `/search/static` now 302-redirects to `/search/crawl`. Hit the new path directly.
3. **`itemName` schema drift.** The product tile dropped `title.preheadline` (the brand prefix), so `itemName` became `"undefined <name>"`. Fall back to `brandName` / `brand.name`.

The earlier "missing slug" symptom was new-format `/p/d/<id>/` URLs hitting a parser that only knew the legacy `-p<id>.html` form; that's already handled by the dual-format `parse` on trunk.

## Test

Green run on a test account (Full / CZ): https://console.apify.com/actors/9jI3TLCF4WleZrq9L/runs/gEd0UtKcQwEbaQgzT

- `requestsFailed: 0`, 551 categories traversed
- 5695 items scraped (aborted mid-catalog once conclusive)
- 1000-item sample: 0 null `itemId`, 0 null `currentPrice`, correct prices, all new-format URLs

Ref #3560
