### PR TITLE
knihydobrovsky-daily: fix pagination next-page selector

### DIFF
--- a/actors/knihydobrovsky-daily/main.js
+++ b/actors/knihydobrovsky-daily/main.js
@@ -132,7 +132,7 @@ async function main() {
       log.info("Processing", { url, label });
       switch (label) {
         case "LIST":
-          const nextPageHref = document.querySelector("nav.paging a.btn-icon-after")?.getAttribute("href");
+          const nextPageHref = document.querySelector("#btn-load-more")?.getAttribute("href");
           if (nextPageHref) {
             const url = canonicalUrl(nextPageHref.trim());
             const pageNumber = url.searchParams.get("currentPage");


### PR DESCRIPTION
Knihy Dobrovský redesigned its category pagination. The actor read the next page from `nav.paging a.btn-icon-after`, but that selector now matches the new scroll-to-top ("Nahoru") button (`href="#sort-filter-box"`) instead of a real next-page link. The crawler therefore built a dead-end URL and never advanced past `currentPage=1` of each category — returning ~3k of the usual ~240k items.

Fix reads the next page from the `#btn-load-more` anchor, whose href already carries the correct `currentPage`. It is present on every page that has a next and absent on the last page, so pagination still terminates cleanly. The existing `offsetPage = currentPage` logic is unchanged.

Green run (TEST, detektivky pages 130→417): 288/288 requests OK, paginated to the last page and stopped, 5360 items from a single category slice (old behaviour: 24). Available books get correct prices; out-of-stock ("Nedostupné") books have no list price and are saved with `currentPrice: null` as before.

https://console.apify.com/actors/cdLgQcZFkYcbCjIyb/runs/AMuRKCaiHggjwbx5v

Ref #3561