### PR TITLE
Fix AAAauto silent block: solve Anubis PoW wall + retry post-Anubis soft-block

### DIFF
--- a/actors/aaaauto-daily/index.js
+++ b/actors/aaaauto-daily/index.js
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { HttpCrawler } from "@crawlee/http";
 import { ActorType } from "@hlidac-shopu/actors-common/actor-type.js";
 import { getInput } from "@hlidac-shopu/actors-common/crawler.js";
@@ -126,13 +127,100 @@ function parseProducts(document, country) {
   });
 }
 
+const ANUBIS_PASS_PATH = "/.within.website/x/cmd/anubis/api/pass-challenge";
+
+/**
+ * aaaauto.cz/.sk sits behind Anubis (Techaro BotStopper), a proof-of-work bot wall.
+ * A cold HTTP request gets a tiny challenge page instead of the catalog, which is why
+ * the actor silently returned 0 / far-too-few items. We solve the PoW in Node and replay
+ * the pass-challenge endpoint to mint the `techaro.lol-anubis-auth` cookie - no browser.
+ * @param {string} html
+ * @returns {boolean}
+ */
+function isAnubisChallenge(html) {
+  return html.includes('id="anubis_challenge"');
+}
+
+/**
+ * Find a nonce so that sha256(randomData + nonce) has `difficulty` leading hex zeros.
+ * Difficulty is 1 in practice (~16 tries), so this is microseconds.
+ * @param {string} randomData
+ * @param {number} difficulty
+ * @returns {{ hash: string, nonce: number }}
+ */
+function solveAnubisPow(randomData, difficulty) {
+  const prefix = "0".repeat(difficulty);
+  for (let nonce = 0; ; nonce++) {
+    const hash = createHash("sha256").update(`${randomData}${nonce}`).digest("hex");
+    if (hash.startsWith(prefix)) return { hash, nonce };
+  }
+}
+
+/**
+ * Build the pass-challenge URL that mints the auth cookie for the given challenge page.
+ * Handles both Anubis algorithms the site rotates through: `fast`/`slow` (PoW) and `metarefresh` (no PoW).
+ * @param {string} html challenge page HTML
+ * @param {string} pageUrl the URL we were trying to reach
+ * @returns {string|null}
+ */
+function buildAnubisPassUrl(html, pageUrl) {
+  const match = html.match(/<script id="anubis_challenge"[^>]*>([\s\S]*?)<\/script>/);
+  if (!match) return null;
+  const parsed = JSON.parse(match[1].trim());
+  // An "oops" page (rejected/stale pass) carries a null challenge - bail so the caller retries cleanly.
+  if (!parsed?.challenge || !parsed?.rules) return null;
+  const { challenge, rules } = parsed;
+  const { origin } = new URL(pageUrl);
+
+  if (rules.algorithm === "metarefresh") {
+    // The server already baked the full pass-challenge URL into the meta refresh tag.
+    const meta = html.match(/http-equiv="refresh"[^>]*url=([^"]+)"/i);
+    if (meta) return new URL(meta[1].replace(/&amp;/g, "&"), origin).toString();
+    const params = new URLSearchParams({ challenge: challenge.randomData, id: challenge.id, redir: pageUrl });
+    return `${origin}${ANUBIS_PASS_PATH}?${params}`;
+  }
+
+  const start = Date.now();
+  const { hash, nonce } = solveAnubisPow(challenge.randomData, rules.difficulty);
+  const params = new URLSearchParams({
+    id: challenge.id,
+    response: hash,
+    nonce: String(nonce),
+    redir: pageUrl,
+    elapsedTime: String(1200 + (Date.now() - start))
+  });
+  return `${origin}${ANUBIS_PASS_PATH}?${params}`;
+}
+
+/**
+ * Return the real HTML for `url`, transparently clearing the Anubis wall if it is served.
+ * `sendRequest` reuses the crawler session's proxy + cookie jar, so the minted auth cookie
+ * is stored and replayed on the session's subsequent page requests.
+ * @param {{ url: string, html: string, sendRequest: Function }} args
+ * @returns {Promise<string>}
+ */
+async function solveAnubisIfNeeded({ url, html, sendRequest }) {
+  for (let attempt = 0; attempt < 3 && isAnubisChallenge(html); attempt++) {
+    const passUrl = buildAnubisPassUrl(html, url);
+    if (!passUrl) break;
+    const response = await sendRequest({ url: passUrl });
+    html = response.body.toString();
+  }
+  if (isAnubisChallenge(html)) {
+    throw new Error(`AAAauto: failed to solve Anubis challenge for ${url}`);
+  }
+  return html;
+}
+
 export async function main() {
   const rollbar = Rollbar.init();
 
   const {
     development,
     debug,
-    maxRequestRetries,
+    // AAA intermittently soft-blocks past Anubis with a "page not found" decoy, so each page may
+    // need a few fresh-session retries to land a real catalog response. Default higher than Crawlee's 3.
+    maxRequestRetries = 8,
     type = ActorType.Full,
     proxyGroups,
     country = Country.CZ
@@ -156,7 +244,7 @@ export async function main() {
   const crawler = new HttpCrawler({
     proxyConfiguration,
     maxRequestRetries,
-    maxRequestsPerMinute: 200,
+    maxRequestsPerMinute: 120,
     useSessionPool: true,
     sessionPoolOptions: {
       maxPoolSize: 20
@@ -164,16 +252,28 @@ export async function main() {
     persistCookiesPerSession: true,
     requestHandlerTimeoutSecs: 300,
     navigationTimeoutSecs: 300,
-    async requestHandler({ request, body }) {
-      const { document } = parseHTML(body.toString());
+    async requestHandler({ request, body, sendRequest, session }) {
+      const html = await solveAnubisIfNeeded({ url: request.url, html: body.toString(), sendRequest });
+      const { document } = parseHTML(html);
 
       const { label } = request.userData;
       log.info(`Label: ${label} - Scraping page ${request.url}`);
+
+      // Past Anubis, AAA intermittently returns a 200 OK "Stránka nenalezena" (page not found) decoy
+      // that parses to zero products - a silent block. Retire the session (fresh proxy IP on retry)
+      // and throw so Crawlee re-fetches the page instead of recording an empty success.
+      const softBlocked = () => {
+        session?.retire();
+        throw new Error(`AAAauto: soft-block "page not found" decoy on ${request.url} - retrying with a fresh session`);
+      };
+
       switch (label) {
         case Label.START:
           {
             const pages = document.querySelectorAll("nav.pagenav li");
-            const lastPage = parseInt(pages[pages.length - 2].querySelector("a").innerText.trim());
+            const lastPageLink = pages[pages.length - 2]?.querySelector("a");
+            if (!lastPageLink) return softBlocked();
+            const lastPage = parseInt(lastPageLink.innerText.trim());
 
             const requests = [];
             for (let i = 0; i < lastPage; i++) {
@@ -190,6 +290,7 @@ export async function main() {
         case Label.PAGE:
           {
             const products = parseProducts(document, country);
+            if (products.length === 0) return softBlocked();
             await Dataset.pushData(products);
           }
           break;


### PR DESCRIPTION
aaaauto.cz/.sk moved behind Anubis (Techaro BotStopper), a proof-of-work bot
wall. Cold HTTP requests got a challenge page instead of the catalog, so the
daily actor silently returned 0 / far-too-few items (the 0-result and ~5k days
in #3562).

Changes (actors/aaaauto-daily):
- Solve the Anubis challenge in-process and replay the pass-challenge endpoint
  to mint the auth cookie, over the existing HttpCrawler session via
  sendRequest - no browser. Handles both algorithms the site rotates through:
  fast/slow (SHA-256 proof-of-work) and metarefresh.
- Past Anubis the site intermittently serves a 200 OK "Stránka nenalezena"
  decoy that parses to zero products. Detect it, retire the session and throw
  so Crawlee retries on a fresh proxy IP. Raise default retries to 8 and lower
  the request rate to keep the soft-block rate down.
- Pin @crawlee/core/types/utils to 3.16.0 so apify@3.7.0 cannot float the
  transitive Crawlee to 3.17.0 and crash the build.

Note: the origin hard-blocks datacenter proxy (590 UPSTREAM502); the actor
needs a residential proxy group.

Green run (yfe404, RESIDENTIAL, FULL CZ):
https://console.apify.com/actors/c6FWczHH6emUtQzda/runs/nRtDv5gQLSMHM0zbF
232/233 requests OK, 11,047 items, 0 null itemId/currentPrice/currency, 0 dups.

Ref #3562
