### PR TITLE
fix(benu-daily): scrape via CZ residential proxy to beat Cloudflare (#3563)

### DIFF
--- a/actors/benu-daily/main.js
+++ b/actors/benu-daily/main.js
@@ -151,15 +151,27 @@ async function main() {
     failed: 0
   });
 
+  // benu.cz is a Czech-only shop behind Cloudflare. Generic (global) residential IPs are largely flagged for it,
+  // so pin the residential pool to Czech exit IPs (#3563). The group itself stays input-driven.
   const proxyConfiguration = await Actor.createProxyConfiguration({
     groups: proxyGroups,
+    countryCode: "CZ",
     useApifyProxy: !development
   });
 
   const crawler = new HttpCrawler({
-    maxRequestRetries,
+    // benu.cz is behind Cloudflare, which 403s a large share of (residential) proxy IPs by reputation (#3563).
+    // A session pool that retires an IP on the first block lets each retry draw a fresh IP, and good IPs are
+    // reused; with enough retries a request survives several bad-IP draws, so the catalog scrapes near-completely.
+    // The single START seed must survive too, so keep a high retry floor (getInput defaults this to just 3).
+    maxRequestRetries: Math.max(maxRequestRetries ?? 0, 10),
     maxRequestsPerMinute: 400,
     proxyConfiguration,
+    useSessionPool: true,
+    persistCookiesPerSession: true,
+    sessionPoolOptions: {
+      sessionOptions: { maxErrorScore: 1 }
+    },
     async requestHandler({ body, request, crawler, sendRequest }) {
       const { document } = parseHTML(body.toString());
       switch (request.userData.label) {


### PR DESCRIPTION
## Problem
The benu-cz daily actor returned **0 results** (#3563). It exited SUCCESS but scraped nothing — a silent block.

## Cause
benu.cz is behind **Cloudflare**, which 403s the datacenter proxy IPs the task used. The first request — the homepage `START` seed — was blocked, so the run found 0 categories and pushed 0 items. From the failing run's log: `Request blocked - received 403 status code` on `https://www.benu.cz`, 3 retries, all 403 → `categories:0, items:0`.

## Fix
All driven off the existing input proxy group (no hardcoded group):
- **`countryCode: "CZ"`** — generic/global residential IPs are largely flagged for this Czech-only shop; pinning Czech exit IPs passes Cloudflare.
- **Session pool** (`maxErrorScore: 1`, `persistCookiesPerSession`) — a blocked IP is retired on the first 403 so each retry draws a fresh IP, and good IPs are reused.
- **Retry floor of 10** (`getInput` defaults it to 3) so the single `START` seed survives the occasional bad-IP draw.

No extension twin change — this is a proxy/anti-bot fix only; the extension scrapes from the user's own browser.

## Green run (yfe404, reduced test account)
FULL run: https://console.apify.com/actors/MZpXf89CVMF9612vL/runs/1tBG5UzDCrP6gIjOo
- START passed (no 403), **67 categories**, **3095 pagination pages**
- **3866 requests, 3 failed (0.08%)**
- **850 items**, 0 null `itemId` / `currentPrice`; discount logic verified (e.g. `currentPrice:79` vs `originalPrice:85`, `discounted:true`)

Before the fix the same crawl had datacenter 403 on the very first request; with generic (non-CZ) residential it was ~95% failures.

Ref #3563