### PR TITLE
fix(lidl-daily): pin @crawlee/core to 3.16.0

### DIFF
--- a/actors/lidl-daily/package.json
+++ b/actors/lidl-daily/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "dependencies": {
     "@crawlee/basic": "3.16.0",
+    "@crawlee/core": "3.16.0",
     "@hckr_/apify-persistent-stats": "1.0.3",
     "@hlidac-shopu/actors-common": "3.2.5",
     "apify": "3.7.0",


### PR DESCRIPTION
Ref #3564

lidl-daily crashed on startup with "Detected incompatible Crawlee version". The Docker build resolves deps with npm, pulling @crawlee/core 3.17.0 for apify while @crawlee/basic needs exactly 3.16.0 — two core versions installed, runtime check failed. Pinned @crawlee/core to 3.16.0 (direct dep, same as tsbohemia-daily) so a single 3.16.0 is used.

Test run (TEST, 2 categories): clean start, 2/2 ok, 0 failed, 49 items.
https://console.apify.com/actors/3L1WVDaN4l6cSxmkl/runs/1occoT7aZVqpCa9cS
