### PR TITLE
fix(extension): render 4camping products without variants

### DIFF
--- a/extension/shops/4camping.mjs
+++ b/extension/shops/4camping.mjs
@@ -3,7 +3,7 @@ import { AsyncShop } from "./shop.mjs";
 
 export class ForCamping extends AsyncShop {
   get waitForSelector() {
-    return "#id_98";
+    return "#formProductAddToBasket";
   }
 
   get injectionPoint() {


### PR DESCRIPTION
Some 4camping product pages do not render the extension because the current wait selector points at the color picker. Products with color variants still work because `#id_98` exists there, but products without color variants do not have that element.

## What changes

Use `#formProductAddToBasket` as the 4camping wait selector.

- This element is already required by the existing scraper, which reads product data from `#formProductAddToBasket.dataset.product`.
- It exists on both tested 4camping product shapes: products with color variants and products without color variants.

## Reproduction

Works before the fix because the color picker exists:

- `https://www.4camping.cz/p/damske-sandaly-regatta-womens-westshore-iv/#36-bezova`

Does not work before the fix because there is no color picker / `#id_98`:

- `https://www.4camping.cz/p/tekute-magnezium-ocun-chalk-liquid-100ml/`

## Verification

DOM evidence from live pages:

- Variant product: `#id_98` present, `#formProductAddToBasket` present, `#priceInfo` present
- Non-variant product: `#id_98` absent, `#formProductAddToBasket` present, `#priceInfo` present
- Homepage/listing-like pages checked: `#formProductAddToBasket` absent

## Screenshots

Current buggy behavior on product without color variants:

![4camping non-variant product without widget](https://github.com/Strajk/hlidac-shopu/releases/download/pr-assets-4camping-rendering-fix/4camping-prefix-nowork.png)

Current working behavior on product with color variants:

![4camping variant product with widget](https://github.com/Strajk/hlidac-shopu/releases/download/pr-assets-4camping-rendering-fix/4camping-prefix-works.png)

---

Code was AI-assisted, but human-verified.
