### PR TITLE
fix(extension): stabilize Pilulka product rendering

### DIFF
--- a/extension/shops/pilulka.mjs
+++ b/extension/shops/pilulka.mjs
@@ -1,37 +1,15 @@
 import { cleanPrice, registerShop } from "../helpers.mjs";
-import { StatefulShop } from "./shop.mjs";
+import { AsyncShop } from "./shop.mjs";
 
-const didRenderDetail = mutations => {
-  const find = mutations.find(x => {
-    return (
-      x.removedNodes.length === 1 &&
-      x.target.nodeName === `DIV` &&
-      x.removedNodes[0].nodeType === 8 &&
-      x.removedNodes[0].previousSibling?.nodeType === 8
-    );
-  });
-  return !!find;
-};
-
-export class Pilulka extends StatefulShop {
-  get detailSelector() {
-    return "nonsense";
+export class Pilulka extends AsyncShop {
+  get waitForSelector() {
+    return "[componentname='catalog.product']";
   }
 
   get injectionPoint() {
+    // Limitation: discontinued/non-purchasable products can miss `ul.usp`
+    // (e.g. https://www.pilulka.cz/indulona-original-85ml).
     return ["afterend", "ul.usp"];
-  }
-
-  shouldRender(mutations) {
-    return didRenderDetail(mutations);
-  }
-
-  shouldCleanup(mutations) {
-    return this.didMutate(mutations, "addedNodes", "menu__item--simple");
-  }
-
-  get observerTarget() {
-    return document.querySelector("#__nuxt");
   }
 
   async scrape() {


### PR DESCRIPTION
Pilulka product pages currently use a custom `StatefulShop` mutation detector that can miss renders or fail when navigating between products. In manual testing, switching to another product could leave the extension in a broken state with `Canvas is already in use`, and some product pages required multiple reloads before the chart appeared. (see videos below)

## What changes

Move Pilulka back to the standard `AsyncShop` lifecycle and wait for the current product root:

- `Pilulka extends AsyncShop` instead of `StatefulShop`
- `waitForSelector` is `[componentname='catalog.product']`
- the custom Nuxt/comment-node mutation detector is removed
- the known limitation around discontinued/non-purchasable products is documented in code

The intent is to rely on the stable product root that Pilulka now exposes, instead of maintaining a shop-specific mutation heuristic.

## Background

The current `StatefulShop` implementation was introduced in 029c2235e for #3394 / #2079, after Pilulka became SPA-like. That made sense at the time, but the current page now exposes a stable product root and the custom mutation detector appears to cause rendering instability.

## Reproduction

Current behavior observed with the unfixed extension:

- switching between Pilulka products can fail to re-render the chart
- the console can report `Canvas is already in use`
- sometimes the chart does not load until repeated reloads

Known lower-priority limitation:

- discontinued/non-purchasable products can miss `ul.usp`, for example:
  - `https://www.pilulka.cz/indulona-original-85ml`

## Verification

Manual verification of the `AsyncShop` version:

- product switching re-rendered the chart correctly
- repeated reloads were stable
- the previous `Canvas is already in use` failure was not reproduced
- the implementation is simpler and uses the shared shop lifecycle

## Videos

Before/current buggy behavior:

[Before: StatefulShop rendering instability](https://github.com/Strajk/hlidac-shopu/releases/download/pr-assets-pilulka-asyncshop-rendering/pilulka-pre-buggy.mp4)

After/working AsyncShop behavior:

[After: AsyncShop rendering stable](https://github.com/Strajk/hlidac-shopu/releases/download/pr-assets-pilulka-asyncshop-rendering/pilulka-after-working.mp4)

---

🤖🤝🤠 Code was AI-assisted, but human-verified.



